### PR TITLE
[improve] added TopicEventListener / topic events for the BrokerService

### DIFF
--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1057,8 +1057,10 @@ public class BrokerService implements Closeable {
 
                                 CompletableFuture<Optional<Topic>> res = createNonPersistentTopic(name);
 
-                                topicEventsDispatcher.notifyOnCompletion(res, topicName.toString(), TopicEvent.CREATE);
-                                topicEventsDispatcher.notifyOnCompletion(res, topicName.toString(), TopicEvent.LOAD);
+                                topicEventsDispatcher.notifyOnCompletion(
+                                        topicEventsDispatcher.notifyOnCompletion(res,
+                                                topicName.toString(), TopicEvent.CREATE),
+                                        topicName.toString(), TopicEvent.LOAD);
                                 return res;
                             }
                             topicEventsDispatcher.notify(topicName.toString(), TopicEvent.LOAD, EventStage.FAILURE);
@@ -1069,8 +1071,9 @@ public class BrokerService implements Closeable {
 
                         CompletableFuture<Optional<Topic>> res = createNonPersistentTopic(name);
 
-                        topicEventsDispatcher.notifyOnCompletion(res, name, TopicEvent.CREATE);
-                        topicEventsDispatcher.notifyOnCompletion(res, name, TopicEvent.LOAD);
+                        topicEventsDispatcher.notifyOnCompletion(
+                                topicEventsDispatcher.notifyOnCompletion(res, name, TopicEvent.CREATE),
+                                name, TopicEvent.LOAD);
                         return res;
                     } else {
                         topicEventsDispatcher.notify(topicName.toString(), TopicEvent.LOAD, EventStage.FAILURE);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -1071,7 +1071,7 @@ public class BrokerService implements Closeable {
 
                         CompletableFuture<Optional<Topic>> res = createNonPersistentTopic(name);
 
-                        CompletableFuture eventFuture = topicEventsDispatcher
+                        CompletableFuture<Optional<Topic>> eventFuture = topicEventsDispatcher
                                 .notifyOnCompletion(res, topicName.toString(), TopicEvent.CREATE);
                         topicEventsDispatcher
                                 .notifyOnCompletion(eventFuture, topicName.toString(), TopicEvent.LOAD);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -55,6 +55,7 @@ import java.util.Set;
 import java.util.concurrent.CancellationException;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.RejectedExecutionException;
@@ -110,6 +111,8 @@ import org.apache.pulsar.broker.service.BrokerServiceException.NamingException;
 import org.apache.pulsar.broker.service.BrokerServiceException.NotAllowedException;
 import org.apache.pulsar.broker.service.BrokerServiceException.PersistenceException;
 import org.apache.pulsar.broker.service.BrokerServiceException.ServiceUnitNotReadyException;
+import org.apache.pulsar.broker.service.TopicEventsListener.EventStage;
+import org.apache.pulsar.broker.service.TopicEventsListener.TopicEvent;
 import org.apache.pulsar.broker.service.nonpersistent.NonPersistentTopic;
 import org.apache.pulsar.broker.service.persistent.DispatchRateLimiter;
 import org.apache.pulsar.broker.service.persistent.PersistentDispatcherMultipleConsumers;
@@ -283,6 +286,8 @@ public class BrokerService implements Closeable {
     private Set<BrokerEntryMetadataInterceptor> brokerEntryMetadataInterceptors;
     private Set<ManagedLedgerPayloadProcessor> brokerEntryPayloadProcessors;
 
+    private final List<TopicEventsListener> topicEventListeners = new CopyOnWriteArrayList<>();
+
     public BrokerService(PulsarService pulsar, EventLoopGroup eventLoopGroup) throws Exception {
         this.pulsar = pulsar;
         this.preciseTopicPublishRateLimitingEnable =
@@ -400,6 +405,60 @@ public class BrokerService implements Closeable {
                         .getBrokerEntryPayloadProcessors(), BrokerService.class.getClassLoader());
 
         this.bundlesQuotas = new BundlesQuotas(pulsar.getLocalMetadataStore());
+    }
+
+    public void addTopicEventListener(TopicEventsListener... listeners) {
+        Objects.requireNonNull(listeners);
+        Arrays.stream(listeners)
+                .filter(x -> x != null)
+                .forEach(topicEventListeners::add);
+        getTopics().keys().forEach(topic ->
+                notifyTopicListeners(listeners, topic, TopicEvent.LOAD, EventStage.SUCCESS, null));
+    }
+
+    public void removeTopicEventListener(TopicEventsListener... listeners) {
+        Objects.requireNonNull(listeners);
+        Arrays.stream(listeners)
+                .filter(x -> x != null)
+                .forEach(topicEventListeners::remove);
+    }
+
+    private void notifyTopicListeners(String topic, TopicEvent event, EventStage stage) {
+        notifyTopicListeners(topic, event, stage, null);
+    }
+
+    private void notifyTopicListeners(String topic, TopicEvent event, EventStage stage, Throwable t) {
+        for (TopicEventsListener listener : topicEventListeners) {
+            try {
+                listener.handleEvent(topic, event, stage, t);
+            } catch (Throwable ex) {
+                log.error("TopicEventsListener exception while handling {}_{} for topic {}", event, stage, topic, ex);
+            }
+        }
+    }
+
+    private <T> CompletableFuture<T> notifyTopicListeners(CompletableFuture<T> future, String topic,
+                                                          TopicEvent event) {
+        future.whenComplete((r, ex) -> notifyTopicListeners(topic,
+                        event,
+                        ex == null ? EventStage.SUCCESS : EventStage.FAILURE,
+                        ex));
+        return future;
+    }
+
+    private static void notifyTopicListeners(TopicEventsListener[] listeners, String topic,
+                                             TopicEvent event, EventStage stage, Throwable t) {
+        if (listeners == null) {
+            return;
+        }
+
+        for (TopicEventsListener listener: listeners) {
+            try {
+                listener.handleEvent(topic, event, stage, t);
+            } catch (Throwable ex) {
+                log.error("TopicEventsListener exception while handling {}_{} for topic {}", event, stage, topic, ex);
+            }
+        }
     }
 
     // This call is used for starting additional protocol handlers
@@ -1033,17 +1092,32 @@ public class BrokerService implements Closeable {
                 });
             } else {
             return topics.computeIfAbsent(topicName.toString(), (name) -> {
+                    notifyTopicListeners(topicName.toString(), TopicEvent.LOAD, EventStage.BEFORE);
                     if (topicName.isPartitioned()) {
                         final TopicName partitionedTopicName = TopicName.get(topicName.getPartitionedTopicName());
                         return this.fetchPartitionedTopicMetadataAsync(partitionedTopicName).thenCompose((metadata) -> {
                             if (topicName.getPartitionIndex() < metadata.partitions) {
-                                return createNonPersistentTopic(name);
+                                notifyTopicListeners(topicName.toString(), TopicEvent.CREATE, EventStage.BEFORE);
+
+                                CompletableFuture<Optional<Topic>> res = createNonPersistentTopic(name);
+
+                                notifyTopicListeners(res, topicName.toString(), TopicEvent.CREATE);
+                                notifyTopicListeners(res, topicName.toString(), TopicEvent.LOAD);
+                                return res;
                             }
+                            notifyTopicListeners(topicName.toString(), TopicEvent.LOAD, EventStage.FAILURE);
                             return CompletableFuture.completedFuture(Optional.empty());
                         });
                     } else if (createIfMissing) {
-                        return createNonPersistentTopic(name);
+                        notifyTopicListeners(name, TopicEvent.CREATE, EventStage.BEFORE);
+
+                        CompletableFuture<Optional<Topic>> res = createNonPersistentTopic(name);
+
+                        notifyTopicListeners(res, name, TopicEvent.CREATE);
+                        notifyTopicListeners(res, name, TopicEvent.LOAD);
+                        return res;
                     } else {
+                        notifyTopicListeners(topicName.toString(), TopicEvent.LOAD, EventStage.FAILURE);
                         return CompletableFuture.completedFuture(Optional.empty());
                     }
                     });
@@ -1064,6 +1138,13 @@ public class BrokerService implements Closeable {
     }
 
     public CompletableFuture<Void> deleteTopic(String topic, boolean forceDelete) {
+        notifyTopicListeners(topic, TopicEvent.DELETE, EventStage.BEFORE);
+        CompletableFuture<Void> result =  deleteTopicInternal(topic, forceDelete);
+        notifyTopicListeners(result, topic, TopicEvent.DELETE);
+        return result;
+    }
+
+    private CompletableFuture<Void> deleteTopicInternal(String topic, boolean forceDelete) {
         TopicName topicName = TopicName.get(topic);
         Optional<Topic> optTopic = getTopicReference(topic);
 
@@ -1424,7 +1505,7 @@ public class BrokerService implements Closeable {
                 log.debug("Broker is unable to load persistent topic {}", topic);
             }
             topicFuture.completeExceptionally(new NotAllowedException(
-                    "Broker is not unable to load persistent topic"));
+                    "Broker is unable to load persistent topic"));
             return topicFuture;
         }
 
@@ -1556,6 +1637,24 @@ public class BrokerService implements Closeable {
                 managedLedgerConfig.setShadowSourceName(TopicName.get(shadowSource).getPersistenceNamingEncoding());
             }
 
+            notifyTopicListeners(topic, TopicEvent.LOAD, EventStage.BEFORE);
+            // load can fail with topicFuture completed non-exceptionally
+            // work around this
+            final CompletableFuture<Void> loadFuture = new CompletableFuture<>();
+            topicFuture.whenComplete((res, ex) -> {
+                if (ex == null) {
+                    loadFuture.complete(null);
+                } else {
+                    loadFuture.completeExceptionally(ex);
+                }
+            });
+
+            if (createIfMissing) {
+                notifyTopicListeners(topic, TopicEvent.CREATE, EventStage.BEFORE);
+                notifyTopicListeners(topicFuture, topic, TopicEvent.CREATE);
+            }
+            notifyTopicListeners(loadFuture, topic, TopicEvent.LOAD);
+
             // Once we have the configuration, we can proceed with the async open operation
             managedLedgerFactory.asyncOpen(topicName.getPersistenceNamingEncoding(), managedLedgerConfig,
                     new OpenLedgerCallback() {
@@ -1627,6 +1726,7 @@ public class BrokerService implements Closeable {
                         public void openLedgerFailed(ManagedLedgerException exception, Object ctx) {
                             if (!createIfMissing && exception instanceof ManagedLedgerNotFoundException) {
                                 // We were just trying to load a topic and the topic doesn't exist
+                                loadFuture.completeExceptionally(exception);
                                 topicFuture.complete(Optional.empty());
                             } else {
                                 log.warn("Failed to create topic {}", topic, exception);
@@ -2100,7 +2200,9 @@ public class BrokerService implements Closeable {
             TopicName topicName = TopicName.get(topic);
             if (serviceUnit.includes(topicName) && getTopicReference(topic).isPresent()) {
                 log.info("[{}][{}] Clean unloaded topic from cache.", serviceUnit.toString(), topic);
+                notifyTopicListeners(topicName.toString(), TopicEvent.UNLOAD, EventStage.BEFORE);
                 pulsar.getBrokerService().removeTopicFromCache(topicName.toString(), serviceUnit, null);
+                notifyTopicListeners(topicName.toString(), TopicEvent.UNLOAD, EventStage.SUCCESS);
             }
         }
     }
@@ -2153,7 +2255,9 @@ public class BrokerService implements Closeable {
         TopicName topicName = TopicName.get(topic);
         return pulsar.getNamespaceService().getBundleAsync(topicName)
                 .thenAccept(namespaceBundle -> {
+                    notifyTopicListeners(topic, TopicEvent.UNLOAD, EventStage.BEFORE);
                     removeTopicFromCache(topic, namespaceBundle, createTopicFuture);
+                    notifyTopicListeners(topic, TopicEvent.UNLOAD, EventStage.SUCCESS);
                 });
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicEventsDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicEventsDispatcher.java
@@ -87,16 +87,15 @@ public class TopicEventsDispatcher {
      * @param topic
      * @param event
      * @param <T>
-     * @return original future
+     * @return future of a new completion stage
      */
     public <T> CompletableFuture<T> notifyOnCompletion(CompletableFuture<T> future,
                                                        String topic,
                                                        TopicEventsListener.TopicEvent event) {
-        future.whenComplete((r, ex) -> notify(topic,
+        return future.whenComplete((r, ex) -> notify(topic,
                 event,
                 ex == null ? TopicEventsListener.EventStage.SUCCESS : TopicEventsListener.EventStage.FAILURE,
                 ex));
-        return future;
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicEventsDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicEventsDispatcher.java
@@ -129,7 +129,8 @@ public class TopicEventsDispatcher {
         try {
             listener.handleEvent(topic, event, stage, t);
         } catch (Throwable ex) {
-            log.error("TopicEventsListener exception while handling {}_{} for topic {}", event, stage, topic, ex);
+            log.error("TopicEventsListener {} exception while handling {}_{} for topic {}",
+                    listener, event, stage, topic, ex);
         }
     }
 

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicEventsDispatcher.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicEventsDispatcher.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CopyOnWriteArrayList;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Utility class to dispatch topic events.
+ */
+@Slf4j
+public class TopicEventsDispatcher {
+    private final List<TopicEventsListener> topicEventListeners = new CopyOnWriteArrayList<>();
+
+    /**
+     * Adds listeners, ignores null listeners.
+     * @param listeners
+     */
+    public void addTopicEventListener(TopicEventsListener... listeners) {
+        Objects.requireNonNull(listeners);
+        Arrays.stream(listeners)
+                .filter(x -> x != null)
+                .forEach(topicEventListeners::add);
+    }
+
+    /**
+     * Removes listeners.
+     * @param listeners
+     */
+    public void removeTopicEventListener(TopicEventsListener... listeners) {
+        Objects.requireNonNull(listeners);
+        Arrays.stream(listeners)
+                .filter(x -> x != null)
+                .forEach(topicEventListeners::remove);
+    }
+
+    /**
+     * Dispatches notification to all currently added listeners.
+     * @param topic
+     * @param event
+     * @param stage
+     */
+    public void notify(String topic,
+                       TopicEventsListener.TopicEvent event,
+                       TopicEventsListener.EventStage stage) {
+        notify(topic, event, stage, null);
+    }
+
+    /**
+     * Dispatches notification to all currently added listeners.
+     * @param topic
+     * @param event
+     * @param stage
+     * @param t
+     */
+    public void notify(String topic,
+                       TopicEventsListener.TopicEvent event,
+                       TopicEventsListener.EventStage stage,
+                       Throwable t) {
+        topicEventListeners
+                .forEach(listener -> notify(listener, topic, event, stage, t));
+    }
+
+    /**
+     * Dispatches SUCCESS/FAILURE notification to all currently added listeners on completion of the future.
+     * @param future
+     * @param topic
+     * @param event
+     * @param <T>
+     * @return original future
+     */
+    public <T> CompletableFuture<T> notifyOnCompletion(CompletableFuture<T> future,
+                                                       String topic,
+                                                       TopicEventsListener.TopicEvent event) {
+        future.whenComplete((r, ex) -> notify(topic,
+                event,
+                ex == null ? TopicEventsListener.EventStage.SUCCESS : TopicEventsListener.EventStage.FAILURE,
+                ex));
+        return future;
+    }
+
+    /**
+     * Dispatches notification to specified listeners.
+     * @param listeners
+     * @param topic
+     * @param event
+     * @param stage
+     * @param t
+     */
+    public static void notify(TopicEventsListener[] listeners,
+                              String topic,
+                              TopicEventsListener.TopicEvent event,
+                              TopicEventsListener.EventStage stage,
+                              Throwable t) {
+        Objects.requireNonNull(listeners);
+        for (TopicEventsListener listener: listeners) {
+            notify(listener, topic, event, stage, t);
+        }
+    }
+
+    private static void notify(TopicEventsListener listener,
+                               String topic,
+                               TopicEventsListener.TopicEvent event,
+                               TopicEventsListener.EventStage stage,
+                               Throwable t) {
+        if (listener == null) {
+            return;
+        }
+
+        try {
+            listener.handleEvent(topic, event, stage, t);
+        } catch (Throwable ex) {
+            log.error("TopicEventsListener exception while handling {}_{} for topic {}", event, stage, topic, ex);
+        }
+    }
+
+}

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicEventsListener.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/TopicEventsListener.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker.service;
+
+import org.apache.pulsar.common.classification.InterfaceAudience;
+import org.apache.pulsar.common.classification.InterfaceStability;
+
+/**
+ * Listener for the Topic events.
+ */
+@InterfaceStability.Evolving
+@InterfaceAudience.LimitedPrivate
+public interface TopicEventsListener {
+
+    /**
+     * Types of events currently supported.
+     *  create/load/unload/delete
+     */
+    enum TopicEvent {
+        // create events included into load events
+        CREATE,
+        LOAD,
+        UNLOAD,
+        DELETE,
+    }
+
+    /**
+     * Stages of events currently supported.
+     *  before starting the event/successful completion/failed completion
+     */
+    enum EventStage {
+        BEFORE,
+        SUCCESS,
+        FAILURE
+    }
+
+    /**
+     * Handle topic event.
+     * Choice of the thread / maintenance of the thread pool is up to the event handlers.
+     * @param topicName - name of the topic
+     * @param event - TopicEvent
+     * @param stage - EventStage
+     * @param t - exception in case of FAILURE, if present/known
+     */
+    void handleEvent(String topicName, TopicEvent event, EventStage stage, Throwable t);
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/TopicEventsListenerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/TopicEventsListenerTest.java
@@ -57,14 +57,14 @@ public class TopicEventsListenerTest extends BrokerTestBase {
     @DataProvider(name = "topicType")
     public static Object[][] topicType() {
         return new Object[][] {
-                {"persistent", "partitioned", Boolean.TRUE},
-                {"persistent", "non-partitioned", Boolean.TRUE},
-                {"non-persistent", "partitioned", Boolean.TRUE},
-                {"non-persistent", "non-partitioned", Boolean.TRUE},
-                {"persistent", "partitioned", Boolean.FALSE},
-                {"persistent", "non-partitioned", Boolean.FALSE},
-                {"non-persistent", "partitioned", Boolean.FALSE},
-                {"non-persistent", "non-partitioned", Boolean.FALSE}
+                {"persistent", "partitioned", true},
+                {"persistent", "non-partitioned", true},
+                {"non-persistent", "partitioned", true},
+                {"non-persistent", "non-partitioned", true},
+                {"persistent", "partitioned", false},
+                {"persistent", "non-partitioned", false},
+                {"non-persistent", "partitioned", false},
+                {"non-persistent", "non-partitioned", false}
         };
     }
 
@@ -122,11 +122,8 @@ public class TopicEventsListenerTest extends BrokerTestBase {
     }
 
     @Test(dataProvider = "topicType")
-    public void testEvents(Object[] topicType) throws Exception {
-        String topicTypePersistence = (String) topicType[0];
-        String topicTypePartitioned = (String) topicType[1];
-        boolean forceDelete = (Boolean) topicType[2];
-
+    public void testEvents(String topicTypePersistence, String topicTypePartitioned,
+                           boolean forceDelete) throws Exception {
         String topicName = topicTypePersistence + "://" + namespace + "/" + "topic-" + UUID.randomUUID();
 
         createTopicAndVerifyEvents(topicTypePartitioned, topicName);
@@ -149,11 +146,8 @@ public class TopicEventsListenerTest extends BrokerTestBase {
     }
 
     @Test(dataProvider = "topicType")
-    public void testEventsWithUnload(Object[] topicType) throws Exception {
-        String topicTypePersistence = (String) topicType[0];
-        String topicTypePartitioned = (String) topicType[1];
-        boolean forceDelete = (Boolean) topicType[2];
-
+    public void testEventsWithUnload(String topicTypePersistence, String topicTypePartitioned,
+                                     boolean forceDelete) throws Exception {
         String topicName = topicTypePersistence + "://" + namespace + "/" + "topic-" + UUID.randomUUID();
 
         createTopicAndVerifyEvents(topicTypePartitioned, topicName);
@@ -184,11 +178,8 @@ public class TopicEventsListenerTest extends BrokerTestBase {
     }
 
     @Test(dataProvider = "topicType")
-    public void testEventsActiveSub(Object[] topicType) throws Exception {
-        String topicTypePersistence = (String) topicType[0];
-        String topicTypePartitioned = (String) topicType[1];
-        boolean forceDelete = (Boolean) topicType[2];
-
+    public void testEventsActiveSub(String topicTypePersistence, String topicTypePartitioned,
+                                    boolean forceDelete) throws Exception {
         String topicName = topicTypePersistence + "://" + namespace + "/" + "topic-" + UUID.randomUUID();
 
         createTopicAndVerifyEvents(topicTypePartitioned, topicName);
@@ -244,10 +235,7 @@ public class TopicEventsListenerTest extends BrokerTestBase {
     }
 
     @Test(dataProvider = "topicTypeNoDelete")
-    public void testTopicAutoGC(Object[] topicType) throws Exception {
-        String topicTypePersistence = (String) topicType[0];
-        String topicTypePartitioned = (String) topicType[1];
-
+    public void testTopicAutoGC(String topicTypePersistence, String topicTypePartitioned) throws Exception {
         String topicName = topicTypePersistence + "://" + namespace + "/" + "topic-" + UUID.randomUUID();
 
         createTopicAndVerifyEvents(topicTypePartitioned, topicName);

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/TopicEventsListenerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/TopicEventsListenerTest.java
@@ -1,0 +1,672 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.broker;
+
+import com.google.common.collect.Sets;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pulsar.broker.service.BrokerTestBase;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.common.policies.data.InactiveTopicDeleteMode;
+import org.apache.pulsar.common.policies.data.InactiveTopicPolicies;
+import org.apache.pulsar.common.policies.data.RetentionPolicies;
+import org.awaitility.Awaitility;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+@Slf4j
+public class TopicEventsListenerTest extends BrokerTestBase {
+
+    final static Queue<String> events = new ConcurrentLinkedQueue<>();
+    String topicNameToWatch;
+    String namespace;
+
+    @BeforeMethod
+    @Override
+    protected void setup() throws Exception {
+        super.baseSetup();
+        pulsar.getConfiguration().setForceDeleteNamespaceAllowed(true);
+
+        pulsar.getBrokerService().addTopicEventListener((topic, event, stage, t) -> {
+            log.info("got event {}__{} for topic {}", event, stage, topic);
+            if (topic.equals(topicNameToWatch)) {
+                if (log.isDebugEnabled()) {
+                    log.debug("got event {}__{} for topic {} with detailed stack",
+                            event, stage, topic, new Exception("tracing event source"));
+                }
+                events.add(event.toString() + "__" + stage.toString());
+            }
+        });
+
+        namespace = "prop/" + UUID.randomUUID();
+        admin.namespaces().createNamespace(namespace, Sets.newHashSet("test"));
+        assertTrue(admin.namespaces().getNamespaces("prop").contains(namespace));
+        admin.namespaces().setRetention(namespace, new RetentionPolicies(3, 10));
+
+        events.clear();
+    }
+
+    @AfterMethod(alwaysRun = true)
+    @Override
+    protected void cleanup() throws Exception {
+        deleteNamespaceWithRetry(namespace, true);
+
+        super.internalCleanup();
+    }
+
+    @Test
+    public void testEventsNonPersistentNonPartitionedTopic() throws Exception {
+        topicNameToWatch = "non-persistent://" + namespace + "/NP-NP";
+        admin.topics().createNonPartitionedTopic(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+            Assert.assertEquals(events.toArray(), new String[]{
+                    "LOAD__BEFORE",
+                    "LOAD__FAILURE",
+                    "LOAD__BEFORE",
+                    "CREATE__BEFORE",
+                    "CREATE__SUCCESS",
+                    "LOAD__SUCCESS"
+            })
+        );
+
+        events.clear();
+        admin.topics().delete(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testEventsNonPersistentNonPartitionedTopicWithUnload() throws Exception {
+        topicNameToWatch = "non-persistent://" + namespace + "/NP-NP";
+        admin.topics().createNonPartitionedTopic(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "LOAD__FAILURE",
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().unload(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().delete(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testEventsNonPersistentNonPartitionedTopicForce() throws Exception {
+        topicNameToWatch = "non-persistent://" + namespace + "/NP-NP";
+        admin.topics().createNonPartitionedTopic(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "LOAD__FAILURE",
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().delete(topicNameToWatch, true);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS",
+                        "DELETE__SUCCESS"
+                })
+        );
+
+    }
+
+    @Test
+    public void testEventsNonPersistentNonPartitionedTopicWithUnloadForce() throws Exception {
+        topicNameToWatch = "non-persistent://" + namespace + "/NP-NP";
+        admin.topics().createNonPartitionedTopic(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "LOAD__FAILURE",
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().unload(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().delete(topicNameToWatch, true);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testEventsPersistentNonPartitionedTopic() throws Exception {
+        topicNameToWatch = "persistent://" + namespace + "/P-NP";
+        admin.topics().createNonPartitionedTopic(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "LOAD__FAILURE",
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().delete(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testEventsPersistentNonPartitionedTopicWithUnload() throws Exception {
+        topicNameToWatch = "persistent://" + namespace + "/P-NP";
+        admin.topics().createNonPartitionedTopic(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "LOAD__FAILURE",
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().unload(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().delete(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testEventsPersistentNonPartitionedTopicForce() throws Exception {
+        topicNameToWatch = "persistent://" + namespace + "/P-NP";
+        admin.topics().createNonPartitionedTopic(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "LOAD__FAILURE",
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().delete(topicNameToWatch, true);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testEventsPersistentNonPartitionedTopicWithUnloadForce() throws Exception {
+        topicNameToWatch = "persistent://" + namespace + "/P-NP";
+        admin.topics().createNonPartitionedTopic(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "LOAD__FAILURE",
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().unload(topicNameToWatch);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().delete(topicNameToWatch, true);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+
+//---------
+
+    @Test
+    public void testEventsNonPersistentPartitionedTopic() throws Exception {
+        String topicName = "non-persistent://" + namespace + "/P-P";
+        topicNameToWatch = topicName + "-partition-1";
+        admin.topics().createPartitionedTopic(topicName, 2);
+        triggerPartitionsCreation(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS",
+                })
+        );
+
+        events.clear();
+
+        admin.topics().deletePartitionedTopic(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testEventsNonPersistentPartitionedTopicWithUnload() throws Exception {
+        String topicName = "non-persistent://" + namespace + "/P-P";
+        topicNameToWatch = topicName + "-partition-1";
+
+        admin.topics().createPartitionedTopic(topicName, 2);
+        triggerPartitionsCreation(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().unload(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().deletePartitionedTopic(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testEventsNonPersistentPartitionedTopicForce() throws Exception {
+        String topicName = "non-persistent://" + namespace + "/P-NP";
+        topicNameToWatch = topicName + "-partition-1";
+        admin.topics().createPartitionedTopic(topicName, 2);
+        triggerPartitionsCreation(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().deletePartitionedTopic(topicName, true);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testEventsNonPersistentPartitionedTopicWithUnloadForce() throws Exception {
+        String topicName = "non-persistent://" + namespace + "/P-NP";
+        topicNameToWatch = topicName + "-partition-1";
+        admin.topics().createPartitionedTopic(topicName, 2);
+        triggerPartitionsCreation(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().unload(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().deletePartitionedTopic(topicName, true);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testEventsPersistentPartitionedTopic() throws Exception {
+        String topicName = "persistent://" + namespace + "/P-NP";
+        topicNameToWatch = topicName + "-partition-1";
+        admin.topics().createPartitionedTopic(topicName, 2);
+        triggerPartitionsCreation(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+
+        admin.topics().deletePartitionedTopic(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testEventsPersistentPartitionedTopicWithUnload() throws Exception {
+        String topicName = "persistent://" + namespace + "/P-NP";
+        topicNameToWatch = topicName + "-partition-0";
+        admin.topics().createPartitionedTopic(topicName, 2);
+        triggerPartitionsCreation(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().unload(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().deletePartitionedTopic(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testEventsPersistentPartitionedTopicForce() throws Exception {
+        String topicName = "persistent://" + namespace + "/P-NP";
+        topicNameToWatch = topicName + "-partition-1";
+
+        admin.topics().createPartitionedTopic(topicName, 2);
+        triggerPartitionsCreation(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().deletePartitionedTopic(topicName, true);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testEventsPersistentPartitionedTopicWithUnloadForce() throws Exception {
+        String topicName = "persistent://" + namespace + "/P-NP";
+        topicNameToWatch = topicName + "-partition-0";
+
+        admin.topics().createPartitionedTopic(topicName, 2);
+        triggerPartitionsCreation(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "LOAD__BEFORE",
+                        "CREATE__BEFORE",
+                        "CREATE__SUCCESS",
+                        "LOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().unload(topicName);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS"
+                })
+        );
+
+        events.clear();
+        admin.topics().deletePartitionedTopic(topicName, true);
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "DELETE__BEFORE",
+                        "DELETE__SUCCESS"
+                })
+        );
+    }
+
+    @Test
+    public void testNonPartitionedTopicAutoGC() throws Exception {
+        topicNameToWatch = "persistent://" + namespace + "/P-NP";
+        admin.topics().createNonPartitionedTopic(topicNameToWatch);
+        admin.namespaces().setInactiveTopicPolicies(namespace,
+                new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions, 1, true));
+
+        // Remove retention
+        admin.namespaces().setRetention(namespace, new RetentionPolicies());
+        events.clear();
+
+        Thread.sleep(1500);
+        runGC();
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS",
+                })
+        );
+
+    }
+
+    @Test
+    public void testPartitionedTopicAutoGC() throws Exception {
+        String topicName = "persistent://" + namespace + "/P-NP";
+        topicNameToWatch = topicName + "-partition-1";
+        admin.topics().createPartitionedTopic(topicName, 2);
+        triggerPartitionsCreation(topicName);
+        admin.namespaces().setInactiveTopicPolicies(namespace,
+                new InactiveTopicPolicies(InactiveTopicDeleteMode.delete_when_no_subscriptions, 1, true));
+
+        // Remove retention
+        admin.namespaces().setRetention(namespace, new RetentionPolicies());
+        events.clear();
+
+        Thread.sleep(1500);
+        runGC();
+
+        Awaitility.waitAtMost(10, TimeUnit.SECONDS).untilAsserted(() ->
+                Assert.assertEquals(events.toArray(), new String[]{
+                        "UNLOAD__BEFORE",
+                        "UNLOAD__SUCCESS",
+                })
+        );
+
+    }
+
+    private void triggerPartitionsCreation(String topicName) throws Exception {
+        Producer<byte[]> producer = pulsarClient.newProducer()
+                .topic(topicName)
+                .create();
+        producer.close();
+    }
+
+}

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerTestBase.java
@@ -79,7 +79,7 @@ public abstract class BrokerTestBase extends MockedPulsarServiceBaseTest {
         }
     }
 
-    void runGC() {
+    protected void runGC() {
         try {
             pulsar.getBrokerService().forEachTopic(topic -> {
                 if (topic instanceof AbstractTopic) {


### PR DESCRIPTION
### Motivation

Topic events for KOP

### Modifications

Added TopicEventsListener interface, topic events dispatching for the BrokerService

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added unit tests

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

Added applicable JavaDoc

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. Please attach the local preview screenshots (run `sh start.sh` at `pulsar/site2/website`) to your PR description, or else your PR might not get merged. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
