### PR TITLE
[fix][io] KCA: Option to use kafka connector's SourceConnector class to create task and task config

### DIFF
--- a/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
+++ b/pulsar-io/kafka-connect-adaptor/src/main/java/org/apache/pulsar/io/kafka/connect/AbstractKafkaConnectSource.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pulsar.io.kafka.connect;
 
+import static com.google.common.base.Preconditions.checkArgument;
+import static com.google.common.base.Preconditions.checkNotNull;
 import io.confluent.connect.avro.AvroConverter;
 import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
 import io.confluent.kafka.serializers.AbstractKafkaAvroSerDeConfig;
@@ -33,7 +35,9 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.kafka.connect.connector.Task;
 import org.apache.kafka.connect.runtime.TaskConfig;
+import org.apache.kafka.connect.source.SourceConnector;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.apache.kafka.connect.source.SourceTaskContext;
@@ -55,6 +59,7 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
 
     // kafka connect related variables
     private SourceTaskContext sourceTaskContext;
+    private SourceConnector connector;
     @Getter
     private SourceTask sourceTask;
     public Converter keyConverter;
@@ -71,6 +76,8 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
     // number of outstandingRecords that have been polled but not been acked
     private final AtomicInteger outstandingRecords = new AtomicInteger(0);
 
+    public static final String CONNECTOR_CLASS = "kafkaConnectorSourceClass";
+
     @Override
     public void open(Map<String, Object> config, SourceContext sourceContext) throws Exception {
         Map<String, String> stringConfig = new HashMap<>();
@@ -79,12 +86,6 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
                 stringConfig.put(key, (String) value);
             }
         });
-
-        // get the source class name from config and create source task from reflection
-        sourceTask = Class.forName(stringConfig.get(TaskConfig.TASK_CLASS_CONFIG))
-                .asSubclass(SourceTask.class)
-                .getDeclaredConstructor()
-                .newInstance();
 
         topicNamespace = stringConfig.get(PulsarKafkaWorkerConfig.TOPIC_NAMESPACE_CONFIG);
 
@@ -129,8 +130,36 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
 
         sourceTaskContext = new PulsarIOSourceTaskContext(offsetReader, pulsarKafkaWorkerConfig);
 
+        final Map<String, String> taskConfig;
+        if (config.get(CONNECTOR_CLASS) != null) {
+            String kafkaConnectorFQClassName = config.get(CONNECTOR_CLASS).toString();
+            Class<?> clazz = Class.forName(kafkaConnectorFQClassName);
+            connector = (SourceConnector) clazz.getConstructor().newInstance();
+
+            Class<? extends Task> taskClass = connector.taskClass();
+            sourceTask = (SourceTask) taskClass.getConstructor().newInstance();
+
+            connector.initialize(new PulsarKafkaSinkContext());
+            connector.start(stringConfig);
+
+            List<Map<String, String>> configs = connector.taskConfigs(1);
+            checkNotNull(configs);
+            checkArgument(configs.size() == 1);
+            taskConfig = configs.get(0);
+        } else {
+            // for backward compatibility with old configuration
+            // that use the task directly
+
+            // get the source class name from config and create source task from reflection
+            sourceTask = Class.forName(stringConfig.get(TaskConfig.TASK_CLASS_CONFIG))
+                    .asSubclass(SourceTask.class)
+                    .getDeclaredConstructor()
+                    .newInstance();
+            taskConfig = stringConfig;
+        }
+
         sourceTask.initialize(sourceTaskContext);
-        sourceTask.start(stringConfig);
+        sourceTask.start(taskConfig);
     }
 
     @Override
@@ -176,6 +205,11 @@ public abstract class AbstractKafkaConnectSource<T> implements Source<T> {
         if (sourceTask != null) {
             sourceTask.stop();
             sourceTask = null;
+        }
+
+        if (connector != null) {
+            connector.stop();
+            connector = null;
         }
 
         if (offsetStore != null) {

--- a/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
+++ b/pulsar-io/kafka-connect-adaptor/src/test/java/org/apache/pulsar/io/kafka/connect/KafkaConnectSourceTest.java
@@ -23,7 +23,6 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-
 import java.io.File;
 import java.io.OutputStream;
 import java.nio.file.Files;
@@ -37,6 +36,7 @@ import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.common.schema.KeyValue;
 import org.apache.pulsar.functions.api.Record;
 import org.apache.pulsar.io.core.SourceContext;
+import org.jetbrains.annotations.NotNull;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -47,7 +47,6 @@ import org.testng.annotations.Test;
 @Slf4j
 public class KafkaConnectSourceTest extends ProducerConsumerBase  {
 
-    private Map<String, Object> config = new HashMap<>();
     private String offsetTopicName;
     // The topic to publish data to, for kafkaSource
     private String topicName;
@@ -62,18 +61,10 @@ public class KafkaConnectSourceTest extends ProducerConsumerBase  {
         super.internalSetup();
         super.producerBaseSetup();
 
-        config.put(TaskConfig.TASK_CLASS_CONFIG, "org.apache.kafka.connect.file.FileStreamSourceTask");
-        config.put(PulsarKafkaWorkerConfig.KEY_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
-        config.put(PulsarKafkaWorkerConfig.VALUE_CONVERTER_CLASS_CONFIG, "org.apache.kafka.connect.storage.StringConverter");
-
         this.offsetTopicName = "persistent://my-property/my-ns/kafka-connect-source-offset";
-        config.put(PulsarKafkaWorkerConfig.OFFSET_STORAGE_TOPIC_CONFIG, offsetTopicName);
-
         this.topicName = "persistent://my-property/my-ns/kafka-connect-source";
-        config.put(FileStreamSourceConnector.TOPIC_CONFIG, topicName);
         tempFile = File.createTempFile("some-file-name", null);
-        config.put(FileStreamSourceConnector.FILE_CONFIG, tempFile.getAbsoluteFile().toString());
-        config.put(FileStreamSourceConnector.TASK_BATCH_SIZE_CONFIG, String.valueOf(FileStreamSourceConnector.DEFAULT_TASK_BATCH_SIZE));
+        tempFile.deleteOnExit();
 
         this.context = mock(SourceContext.class);
         this.client = PulsarClient.builder()
@@ -91,16 +82,45 @@ public class KafkaConnectSourceTest extends ProducerConsumerBase  {
         tempFile.delete();
         super.internalCleanup();
     }
-    protected void completedFlush(Throwable error, Void result) {
-        if (error != null) {
-            log.error("Failed to flush {} offsets to storage: ", this, error);
-        } else {
-            log.info("Finished flushing {} offsets to storage", this);
-        }
+
+    @Test
+    public void testOpenAndReadConnectorConfig() throws Exception {
+        Map<String, Object> config = getConfig();
+        config.put(AbstractKafkaConnectSource.CONNECTOR_CLASS,
+                "org.apache.kafka.connect.file.FileStreamSourceConnector");
+
+        testOpenAndReadTask(config);
     }
 
     @Test
-    public void testOpenAndRead() throws Exception {
+    public void testOpenAndReadTaskDirect() throws Exception {
+        Map<String, Object> config = getConfig();
+
+        config.put(TaskConfig.TASK_CLASS_CONFIG,
+                "org.apache.kafka.connect.file.FileStreamSourceTask");
+
+        testOpenAndReadTask(config);
+    }
+
+    @NotNull
+    private Map<String, Object> getConfig() {
+        Map<String, Object> config = new HashMap<>();
+
+        config.put(PulsarKafkaWorkerConfig.KEY_CONVERTER_CLASS_CONFIG,
+                "org.apache.kafka.connect.storage.StringConverter");
+        config.put(PulsarKafkaWorkerConfig.VALUE_CONVERTER_CLASS_CONFIG,
+                "org.apache.kafka.connect.storage.StringConverter");
+
+        config.put(PulsarKafkaWorkerConfig.OFFSET_STORAGE_TOPIC_CONFIG, offsetTopicName);
+
+        config.put(FileStreamSourceConnector.TOPIC_CONFIG, topicName);
+        config.put(FileStreamSourceConnector.FILE_CONFIG, tempFile.getAbsoluteFile().toString());
+        config.put(FileStreamSourceConnector.TASK_BATCH_SIZE_CONFIG,
+                String.valueOf(FileStreamSourceConnector.DEFAULT_TASK_BATCH_SIZE));
+        return config;
+    }
+
+    private void testOpenAndReadTask(Map<String, Object> config) throws Exception {
         kafkaConnectSource = new KafkaConnectSource();
         kafkaConnectSource.open(config, context);
 


### PR DESCRIPTION
### Motivation

KCA's SourceConnector uses Kafka's task name as a parameter and creates the task directly.
this works well enough for simpler or old sources (e.g. deebzium's potgre/mysql/mongo etc).
Actual expected life cycle is to create a connector, then get the task class and the task config from it.
Connectors that rely on such cycle do not work with KCA, e.g. yugabyte's debezium source. See 
https://apache-pulsar.slack.com/archives/C5Z4T36F7/p1677506713032549 for details.

### Modifications

Added option to pass source connector's class name, made use of it.
Kept the KCA compatible with old configuration, falling back to the legacy behavior if the config is not set.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added unit test.

### Does this pull request potentially affect one of the following parts:

NO

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
