### PR TITLE
[improve][client]: add --streaming option to topics partitioned-stats-internal

### DIFF
--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pulsar.client.admin;
 
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -1206,6 +1207,26 @@ public interface Topics {
      */
     PersistentTopicInternalStats getInternalStats(String topic, boolean metadata) throws PulsarAdminException;
 
+
+    /**
+     * Get the internal stats for the topic in a streaming fashion.
+     * <p/>
+     *
+     * @param topic
+     *            topic name
+     * @param metadata
+     *            flag to include ledger metadata
+     * @return the topic statistics
+     *
+     * @throws NotAuthorizedException
+     *             Don't have admin permission
+     * @throws NotFoundException
+     *             Topic does not exist
+     * @throws PulsarAdminException
+     *             Unexpected error
+     */
+    InputStream streamInternalStats(String topic, boolean metadata) throws PulsarAdminException;
+
     /**
      * Get the internal stats for the topic.
      * <p/>
@@ -1234,6 +1255,17 @@ public interface Topics {
      * @return a future that can be used to track when the internal topic statistics are returned
      */
     CompletableFuture<PersistentTopicInternalStats> getInternalStatsAsync(String topic, boolean metadata);
+
+    /**
+     * Get the internal stats for the topic asynchronously in a streaming fashion.
+     *
+     * @param topic
+     *            topic Name
+     * @param metadata
+     *            flag to include ledger metadata
+     * @return a future that can be used to track when the internal topic statistics are returned
+     */
+    CompletableFuture<InputStream> streamInternalStatsAsync(String topic, boolean metadata);
 
     /**
      * Get the internal stats for the topic asynchronously.
@@ -1404,6 +1436,27 @@ public interface Topics {
      * @return a future that can be used to track when the partitioned topic statistics are returned
      */
     CompletableFuture<PartitionedTopicInternalStats> getPartitionedInternalStatsAsync(String topic);
+
+
+    /**
+     * Get the stats for the partitioned topic in a streaming fashion.
+     *
+     * @param topic
+     *            topic name
+     * @return
+     * @throws PulsarAdminException
+     */
+    InputStream streamPartitionedInternalStats(String topic)
+            throws PulsarAdminException;
+
+    /**
+     * Get the stats-internal for the partitioned topic asynchronously in a streaming fashion.
+     *
+     * @param topic
+     *            topic Name
+     * @return a future that can be used to track when the partitioned topic statistics are returned
+     */
+    CompletableFuture<InputStream> streamPartitionedInternalStatsAsync(String topic);
 
     /**
      * Delete a subscription.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -44,7 +44,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
-
 import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.admin.ListTopicsOptions;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -44,6 +44,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
+
 import org.apache.pulsar.client.admin.GetStatsOptions;
 import org.apache.pulsar.client.admin.ListTopicsOptions;
 import org.apache.pulsar.client.admin.LongRunningProcessStatus;
@@ -675,6 +676,20 @@ public class TopicsImpl extends BaseResource implements Topics {
     }
 
     @Override
+    public InputStream streamInternalStats(String topic, boolean metadata) throws PulsarAdminException {
+        return sync(() -> streamInternalStatsAsync(topic, metadata));
+    }
+
+    @Override
+    public CompletableFuture<InputStream> streamInternalStatsAsync(String topic, boolean metadata) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "internalStats");
+        path = path.queryParam("metadata", metadata);
+        CompletableFuture<InputStream> future = new CompletableFuture<>();
+        return asyncGetRequest(path, new FutureCallback<InputStream>() {});
+    }
+
+    @Override
     public String getInternalInfo(String topic) throws PulsarAdminException {
         return sync(() -> getInternalInfoAsync(topic));
     }
@@ -774,6 +789,18 @@ public class TopicsImpl extends BaseResource implements Topics {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "partitioned-internalStats");
         return asyncGetRequest(path, new FutureCallback<PartitionedTopicInternalStats>(){});
+    }
+
+    @Override
+    public InputStream streamPartitionedInternalStats(String topic) throws PulsarAdminException {
+        return sync(() -> streamPartitionedInternalStatsAsync(topic));
+    }
+
+    @Override
+    public CompletableFuture<InputStream> streamPartitionedInternalStatsAsync(String topic) {
+        TopicName tn = validateTopic(topic);
+        WebTarget path = topicPath(tn, "partitioned-internalStats");
+        return asyncGetRequest(path, new FutureCallback<InputStream>(){});
     }
 
     @Override

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -684,7 +684,6 @@ public class TopicsImpl extends BaseResource implements Topics {
         TopicName tn = validateTopic(topic);
         WebTarget path = topicPath(tn, "internalStats");
         path = path.queryParam("metadata", metadata);
-        CompletableFuture<InputStream> future = new CompletableFuture<>();
         return asyncGetRequest(path, new FutureCallback<InputStream>() {});
     }
 

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -38,8 +38,11 @@ import static org.testng.AssertJUnit.assertNotNull;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
+import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.InputStream;
 import java.io.PrintStream;
 import java.io.PrintWriter;
 import java.net.URL;
@@ -1560,6 +1563,11 @@ public class PulsarAdminToolTest {
         Lookup mockLookup = mock(Lookup.class);
         when(admin.lookups()).thenReturn(mockLookup);
 
+        String statsString = "{}";
+        InputStream stream = new ByteArrayInputStream(statsString.getBytes(StandardCharsets.UTF_8));
+        when(mockTopics.streamInternalStats("persistent://myprop/clust/ns1/ds1", false)).thenReturn(stream);
+        when(mockTopics.streamPartitionedInternalStats("persistent://myprop/clust/ns1/ds1")).thenReturn(stream);
+
         CmdTopics cmdTopics = new CmdTopics(() -> admin);
 
         cmdTopics.run(split("truncate persistent://myprop/clust/ns1/ds1"));
@@ -1606,6 +1614,9 @@ public class PulsarAdminToolTest {
 
         cmdTopics.run(split("stats-internal persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getInternalStats("persistent://myprop/clust/ns1/ds1", false);
+
+        cmdTopics.run(split("stats-internal persistent://myprop/clust/ns1/ds1 --streaming"));
+        verify(mockTopics).streamInternalStats("persistent://myprop/clust/ns1/ds1", false);
 
         cmdTopics.run(split("get-backlog-quotas persistent://myprop/clust/ns1/ds1 -ap"));
         verify(mockTopics).getBacklogQuotaMap("persistent://myprop/clust/ns1/ds1", true);
@@ -1654,6 +1665,9 @@ public class PulsarAdminToolTest {
 
         cmdTopics.run(split("partitioned-stats-internal persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getPartitionedInternalStats("persistent://myprop/clust/ns1/ds1");
+
+        cmdTopics.run(split("partitioned-stats-internal persistent://myprop/clust/ns1/ds1 --streaming"));
+        verify(mockTopics).streamPartitionedInternalStats("persistent://myprop/clust/ns1/ds1");
 
         cmdTopics.run(split("clear-backlog persistent://myprop/clust/ns1/ds1 -s sub1"));
         verify(mockTopics).skipAllMessages("persistent://myprop/clust/ns1/ds1", "sub1");

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -833,7 +833,7 @@ public class CmdTopics extends CmdBase {
         void run() throws Exception {
             String topic = validateTopicName(topicName);
             if (streaming) {
-                try (InputStream in = getTopics().streamPartitionedInternalStats(topic);) {
+                try (InputStream in = getTopics().streamPartitionedInternalStats(topic)) {
                     int size;
                     byte[] buffer = new byte[2048];
                     while ((size = in.read(buffer)) != -1) {

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -28,10 +28,8 @@ import com.google.gson.JsonParser;
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.ByteBufUtil;
 import io.netty.buffer.Unpooled;
-import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -750,18 +748,20 @@ public class CmdTopics extends CmdBase {
         @Option(names = { "-m",
         "--metadata" }, description = "Flag to include ledger metadata")
         private boolean metadata = false;
-        @Parameter(names = "--streaming", description = "Streaming the output directly to the standard output without " +
-                "parsing the response in memory.")
+        @Option(names = "--streaming", description = "Streaming the output directly to the standard output without "
+                + "parsing the response in memory.")
         private boolean streaming = false;
 
         @Override
         void run() throws PulsarAdminException, IOException {
-            String persistentTopic = validatePersistentTopic(params);
+            String persistentTopic = validatePersistentTopic(topicName);
             if (streaming) {
                 try (InputStream in = getTopics().streamInternalStats(persistentTopic, metadata);) {
                     int size;
                     byte[] buffer = new byte[2048];
-                    while ((size = in.read(buffer)) != -1) System.out.write(buffer, 0, size);
+                    while ((size = in.read(buffer)) != -1) {
+                        System.out.write(buffer, 0, size);
+                    }
                 }
             } else {
                 print(getTopics().getInternalStats(persistentTopic, metadata));
@@ -825,8 +825,8 @@ public class CmdTopics extends CmdBase {
     private class GetPartitionedStatsInternal extends CliCommand {
         @Parameters(description = "persistent://tenant/namespace/topic", arity = "1")
         private String topicName;
-        @Parameter(names = "--streaming", description = "Streaming the output directly to the standard output without " +
-                "parsing the response in memory.")
+        @Option(names = "--streaming", description = "Streaming the output directly to the standard output without "
+                + "parsing the response in memory.")
         private boolean streaming = false;
 
         @Override
@@ -836,7 +836,9 @@ public class CmdTopics extends CmdBase {
                 try (InputStream in = getTopics().streamPartitionedInternalStats(topic);) {
                     int size;
                     byte[] buffer = new byte[2048];
-                    while ((size = in.read(buffer)) != -1) System.out.write(buffer, 0, size);
+                    while ((size = in.read(buffer)) != -1) {
+                        System.out.write(buffer, 0, size);
+                    }
                 }
             } else {
                 print(getTopics().getPartitionedInternalStats(topic));

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -754,9 +754,9 @@ public class CmdTopics extends CmdBase {
 
         @Override
         void run() throws PulsarAdminException, IOException {
-            String persistentTopic = validatePersistentTopic(topicName);
+            String topic = validateTopicName(topicName);
             if (streaming) {
-                try (InputStream in = getTopics().streamInternalStats(persistentTopic, metadata);) {
+                try (InputStream in = getTopics().streamInternalStats(topic, metadata);) {
                     int size;
                     byte[] buffer = new byte[2048];
                     while ((size = in.read(buffer)) != -1) {
@@ -764,7 +764,7 @@ public class CmdTopics extends CmdBase {
                     }
                 }
             } else {
-                print(getTopics().getInternalStats(persistentTopic, metadata));
+                print(getTopics().getInternalStats(topic, metadata));
             }
         }
     }


### PR DESCRIPTION
### Motivation

Streaming the stats output directly to the standard output without parsing the response in memory.

### Modifications

added `--streaming` flag for  `topics stats-internal/partitioned-stats-internal` commands to stream the stats.

### Verifying this change

- [ ] Make sure that the change passes the CI checks.

This change added unit tests.

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

**added `--streaming` flag for  `topics stats-internal/partitioned-stats-internal` commands**

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [x] **The admin CLI options**
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
