### PR TITLE
Fix: Prevent IllegalStateException: Field 'message' is not set

### DIFF
--- a/buildtools/pom.xml
+++ b/buildtools/pom.xml
@@ -62,6 +62,7 @@
     <snakeyaml.version>2.0</snakeyaml.version>
     <mockito.version>5.17.0</mockito.version>
     <byte-buddy.version>1.15.11</byte-buddy.version>
+    <wagon-ssh-external.version>3.5.3</wagon-ssh-external.version>
     <!-- required for running tests on JDK11+ -->
     <test.additional.args>
       --add-opens java.base/jdk.internal.loader=ALL-UNNAMED
@@ -295,7 +296,7 @@
       <extension>
         <groupId>org.apache.maven.wagon</groupId>
         <artifactId>wagon-ssh-external</artifactId>
-        <version>3.5.3</version>
+        <version>${wagon-ssh-external.version}</version>
       </extension>
     </extensions>
   </build>

--- a/distribution/server/src/assemble/LICENSE.bin.txt
+++ b/distribution/server/src/assemble/LICENSE.bin.txt
@@ -481,8 +481,8 @@ The Apache Software License, Version 2.0
   * Prometheus
     - io.prometheus-simpleclient_httpserver-0.16.0.jar
   * Oxia
-    - io.streamnative.oxia-oxia-client-api-0.5.0.jar
-    - io.streamnative.oxia-oxia-client-0.5.0.jar
+    - io.github.oxia-db-oxia-client-api-0.6.0.jar
+    - io.github.oxia-db-oxia-client-0.6.0.jar
   * OpenHFT
     - net.openhft-zero-allocation-hashing-0.16.jar
   * Java JSON WebTokens

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -219,10 +219,10 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
      * This lock is held while the ledgers list or propertiesMap is updated asynchronously on the metadata store.
      * Since we use the store version, we cannot have multiple concurrent updates.
      */
-    private final CallbackMutex metadataMutex = new CallbackMutex();
-    private final CallbackMutex trimmerMutex = new CallbackMutex();
+    protected final CallbackMutex metadataMutex = new CallbackMutex();
+    protected final CallbackMutex trimmerMutex = new CallbackMutex();
 
-    private final CallbackMutex offloadMutex = new CallbackMutex();
+    protected final CallbackMutex offloadMutex = new CallbackMutex();
     public static final CompletableFuture<Position> NULL_OFFLOAD_PROMISE = CompletableFuture
             .completedFuture(PositionFactory.LATEST);
     @VisibleForTesting

--- a/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
+++ b/managed-ledger/src/main/java/org/apache/bookkeeper/mledger/impl/ManagedLedgerImpl.java
@@ -2980,7 +2980,15 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
                     for (LedgerInfo ls : offloadedLedgersToDelete) {
                         log.info("[{}] Deleting offloaded ledger {} from bookkeeper - size: {}", name, ls.getLedgerId(),
                                 ls.getSize());
-                        asyncDeleteLedgerFromBookKeeper(ls.getLedgerId());
+                        invalidateReadHandle(ls.getLedgerId());
+                        asyncDeleteLedgerFromBookKeeper(ls.getLedgerId()).thenAccept(__ -> {
+                            log.info("[{}] Deleted and invalidated offloaded ledger {} from bookkeeper - size: {}",
+                                    name, ls.getLedgerId(), ls.getSize());
+                        }).exceptionally(ex -> {
+                            log.error("[{}] Failed to delete offloaded ledger {} from bookkeeper - size: {}",
+                                    name, ls.getLedgerId(), ls.getSize(), ex);
+                            return null;
+                        });
                     }
                     promise.complete(null);
                 }
@@ -3201,8 +3209,8 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
-    private void asyncDeleteLedgerFromBookKeeper(long ledgerId) {
-        asyncDeleteLedger(ledgerId, DEFAULT_LEDGER_DELETE_RETRIES);
+    private CompletableFuture<Void> asyncDeleteLedgerFromBookKeeper(long ledgerId) {
+        return asyncDeleteLedger(ledgerId, DEFAULT_LEDGER_DELETE_RETRIES);
     }
 
     private void asyncDeleteLedger(long ledgerId, LedgerInfo info) {
@@ -3219,22 +3227,32 @@ public class ManagedLedgerImpl implements ManagedLedger, CreateCallback {
         }
     }
 
-    private void asyncDeleteLedger(long ledgerId, long retry) {
-        if (retry <= 0) {
-            log.warn("[{}] Failed to delete ledger after retries {}", name, ledgerId);
-            return;
-        }
+    private CompletableFuture<Void> asyncDeleteLedger(long ledgerId, long retry) {
+        CompletableFuture<Void> future = new CompletableFuture<>();
+        asyncDeleteLedgerWithRetry(future, ledgerId, retry);
+        return future;
+    }
+
+    private void asyncDeleteLedgerWithRetry(CompletableFuture<Void> future, long ledgerId, long retry) {
         bookKeeper.asyncDeleteLedger(ledgerId, (rc, ctx) -> {
             if (isNoSuchLedgerExistsException(rc)) {
                 log.warn("[{}] Ledger was already deleted {}", name, ledgerId);
+                future.complete(null);
             } else if (rc != BKException.Code.OK) {
                 log.error("[{}] Error deleting ledger {} : {}", name, ledgerId, BKException.getMessage(rc));
+                if (retry <= 1) {
+                    // The latest once of retry has failed
+                    log.warn("[{}] Failed to delete ledger after retries {}, code: {}", name, ledgerId, rc);
+                    future.completeExceptionally(BKException.create(rc));
+                    return;
+                }
                 scheduledExecutor.schedule(() -> asyncDeleteLedger(ledgerId, retry - 1),
                         DEFAULT_LEDGER_DELETE_BACKOFF_TIME_SEC, TimeUnit.SECONDS);
             } else {
                 if (log.isDebugEnabled()) {
                     log.debug("[{}] Deleted ledger {}", name, ledgerId);
                 }
+                future.complete(null);
             }
         }, null);
     }

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadLedgerDeleteTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadLedgerDeleteTest.java
@@ -26,18 +26,27 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
+import org.apache.bookkeeper.client.BKException;
 import org.apache.bookkeeper.client.api.ReadHandle;
+import org.apache.bookkeeper.mledger.AsyncCallbacks;
+import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.LedgerOffloader;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
+import org.apache.bookkeeper.mledger.ManagedLedgerException;
+import org.apache.bookkeeper.mledger.Position;
+import org.apache.bookkeeper.mledger.PositionFactory;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
 import org.apache.bookkeeper.mledger.util.MockClock;
 import org.apache.bookkeeper.test.MockedBookKeeperTestCase;
 
 import org.apache.pulsar.common.policies.data.OffloadPoliciesImpl;
+import org.apache.pulsar.common.policies.data.OffloadedReadPriority;
+import org.awaitility.Awaitility;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -205,6 +214,125 @@ public class OffloadLedgerDeleteTest extends MockedBookKeeperTestCase {
 
         Assert.assertEquals(ledger.getLedgersInfoAsList().size(), 1);
         assertEventuallyTrue(() -> offloader.deletedOffloads().contains(firstLedgerId));
+    }
+
+    @Test
+    public void testGetReadLedgerHandleAfterTrimOffloadedLedgers() throws Exception {
+        // Create managed ledger.
+        final long offloadThresholdSeconds = 5;
+        final long offloadDeletionLagInSeconds = 1;
+        OffloadPrefixTest.MockLedgerOffloader offloader = new OffloadPrefixTest.MockLedgerOffloader();
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setMaxEntriesPerLedger(10);
+        config.setMinimumRolloverTime(0, TimeUnit.SECONDS);
+        config.setRetentionTime(10, TimeUnit.MINUTES);
+        config.setRetentionSizeInMB(10);
+        offloader.getOffloadPolicies().setManagedLedgerOffloadDeletionLagInMillis(offloadDeletionLagInSeconds * 1000);
+        offloader.getOffloadPolicies().setManagedLedgerOffloadThresholdInSeconds(offloadThresholdSeconds);
+        offloader.getOffloadPolicies().setManagedLedgerOffloadedReadPriority(OffloadedReadPriority.BOOKKEEPER_FIRST);
+        config.setLedgerOffloader(offloader);
+        ManagedLedgerImpl ml =
+                (ManagedLedgerImpl)factory.open("testGetReadLedgerHandleAfterTrimOffloadedLedgers", config);
+        ml.openCursor("c1");
+
+        // Write entries.
+        int i = 0;
+        for (; i < 35; i++) {
+            String content = "entry-" + i;
+            ml.addEntry(content.getBytes());
+        }
+        Assert.assertEquals(ml.getLedgersInfoAsList().size(), 4);
+        long ledger1 = ml.getLedgersInfoAsList().get(0).getLedgerId();
+        long ledger2 = ml.getLedgersInfoAsList().get(1).getLedgerId();
+        long ledger3 = ml.getLedgersInfoAsList().get(2).getLedgerId();
+        long ledger4 = ml.getLedgersInfoAsList().get(3).getLedgerId();
+
+        // Offload ledgers.
+        Thread.sleep(offloadThresholdSeconds * 2 * 1000);
+        CompletableFuture<Position> offloadFuture = new CompletableFuture<Position>();
+        ml.maybeOffloadInBackground(offloadFuture);
+        offloadFuture.join();
+
+        // Cache ledger handle.
+        CountDownLatch readCountDownLatch = new CountDownLatch(4);
+        AsyncCallbacks.ReadEntryCallback readCb = new AsyncCallbacks.ReadEntryCallback(){
+
+            @Override
+            public void readEntryComplete(Entry entry, Object ctx) {
+                readCountDownLatch.countDown();
+            }
+
+            @Override
+            public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                readCountDownLatch.countDown();
+            }
+        };
+        ml.asyncReadEntry(PositionFactory.create(ledger1, 0), readCb, null);
+        ml.asyncReadEntry(PositionFactory.create(ledger2, 0), readCb, null);
+        ml.asyncReadEntry(PositionFactory.create(ledger3, 0), readCb, null);
+        ml.asyncReadEntry(PositionFactory.create(ledger4, 0), readCb, null);
+        readCountDownLatch.await();
+        ReadHandle originalReadHandle4 = ml.getLedgerHandle(ledger4).join();
+
+        // Trim offloaded BK ledger handles.
+        Thread.sleep(offloadDeletionLagInSeconds * 2 * 1000);
+        CompletableFuture<Position> trimLedgerFuture = new CompletableFuture<Position>();
+        ml.internalTrimLedgers(false, trimLedgerFuture);
+        trimLedgerFuture.join();
+        MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfo1 = ml.getLedgerInfo(ledger1).get();
+        MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfo2 = ml.getLedgerInfo(ledger2).get();
+        MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfo3 = ml.getLedgerInfo(ledger3).get();
+        MLDataFormats.ManagedLedgerInfo.LedgerInfo ledgerInfo4 = ml.getLedgerInfo(ledger4).get();
+        Assert.assertTrue(ledgerInfo1.hasOffloadContext() && ledgerInfo1.getOffloadContext().getBookkeeperDeleted());
+        Assert.assertTrue(ledgerInfo2.hasOffloadContext() && ledgerInfo2.getOffloadContext().getBookkeeperDeleted());
+        Assert.assertTrue(ledgerInfo3.hasOffloadContext() && ledgerInfo3.getOffloadContext().getBookkeeperDeleted());
+        Assert.assertFalse(ledgerInfo4.hasOffloadContext() || ledgerInfo4.getOffloadContext().getBookkeeperDeleted());
+
+        Awaitility.await().untilAsserted(() -> {
+            try {
+                factory.getBookKeeper().get().openLedger(ledger3, ml.digestType, ml.config.getPassword());
+                Assert.fail("Should fail: the ledger has been deleted");
+            } catch (BKException.BKNoSuchLedgerExistsException ex) {
+                // Expected.
+            }
+            try {
+                factory.getBookKeeper().get().openLedger(ledger2, ml.digestType, ml.config.getPassword());
+                Assert.fail("Should fail: the ledger has been deleted");
+            } catch (BKException.BKNoSuchLedgerExistsException ex) {
+                // Expected.
+            }
+            try {
+                factory.getBookKeeper().get().openLedger(ledger1, ml.digestType, ml.config.getPassword());
+                Assert.fail("Should fail: the ledger has been deleted");
+            } catch (BKException.BKNoSuchLedgerExistsException ex) {
+                // Expected.
+            }
+        });
+
+        // Verify: "ml.getLedgerHandle" returns a correct ledger handle.
+        ReadHandle currentReadHandle4 = ml.getLedgerHandle(ledger4).join();
+        Assert.assertEquals(currentReadHandle4, originalReadHandle4);
+        try {
+            ml.getLedgerHandle(ledger3).join();
+            Assert.fail("should get a failure: MockLedgerOffloader does not support read");
+        } catch (Exception ex) {
+            Assert.assertTrue(ex.getCause().getCause().getMessage()
+                    .contains("MockLedgerOffloader does not support read"));
+        }
+        try {
+            ml.getLedgerHandle(ledger2).join();
+            Assert.fail("should get a failure: MockLedgerOffloader does not support read");
+        } catch (Exception ex) {
+            Assert.assertTrue(ex.getCause().getCause().getMessage()
+                    .contains("MockLedgerOffloader does not support read"));
+        }
+        try {
+            ml.getLedgerHandle(ledger1).join();
+            Assert.fail("should get a failure: MockLedgerOffloader does not support read");
+        } catch (Exception ex) {
+            Assert.assertTrue(ex.getCause().getCause().getMessage()
+                    .contains("MockLedgerOffloader does not support read"));
+        }
     }
 
     @Test(timeOut = 5000)

--- a/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
+++ b/managed-ledger/src/test/java/org/apache/bookkeeper/mledger/impl/OffloadPrefixTest.java
@@ -1293,7 +1293,7 @@ public class OffloadPrefixTest extends MockedBookKeeperTestCase {
         public CompletableFuture<ReadHandle> readOffloaded(long ledgerId, UUID uuid,
                                                            Map<String, String> offloadDriverMetadata) {
             CompletableFuture<ReadHandle> promise = new CompletableFuture<>();
-            promise.completeExceptionally(new UnsupportedOperationException());
+            promise.completeExceptionally(new UnsupportedOperationException("MockLedgerOffloader does not support read"));
             return promise;
         }
 

--- a/pip/pip-425.md
+++ b/pip/pip-425.md
@@ -1,0 +1,147 @@
+# PIP-425: Support connecting with next available endpoint for multi-endpoint serviceUrls
+Implementation PR: [#24387](https://github.com/apache/pulsar/pull/24387)
+# Abstract
+This proposal introduces a mechanism for the Pulsar client to gracefully handle unavailable service endpoints. When configured with a multi-endpoint service URL, the client will temporarily quarantine unresponsive endpoints and automatically attempt to connect to the next available one. This change introduces an intelligent failover strategy with exponential backoff, significantly improving the client's connection reliability and resilience in environments where broker availability can fluctuate.
+# Background knowledge
+In the current Pulsar client versions, consumer or producer creation is the responsibility of PulsarClient, we can build a PulsarClient by pass serviceUrl param. The serviceUrl param supports multiple endpoints with the syntax `pulsar://host1:6650,host2:6650,host3:6650,...` or `pulsar+ssl://host1:6651,host2:6651,host3:6651,...`. When a Pulsar client tries to create a producer or consumer, it may pick an endpoint from the list that is temporarily unavailable. The creation will fail, but worse, subsequent attempts may continue to pick the same unavailable endpoint, leading to repeated failures. This occurs even when other endpoints in the list are perfectly healthy and available.
+
+```java
+public class Example {
+    public static void main(String[] args) throws PulsarClientException {
+        PulsarClient pulsarClient = PulsarClient.builder()
+                .serviceUrl("pulsar://host1:6650,host2:6650,host3:6650")
+                .build();
+        Consumer<Long> consumer = pulsarClient.newConsumer(Schema.INT64)
+                .topic("persistent://public/default/my-topic")
+                .subscriptionName("my-subscription")
+                .subscribe();
+
+        Producer<Long> producer = pulsarClient.newProducer(Schema.INT64)
+                .topic("persistent://public/default/my-topic")
+                .create();   
+
+        .....
+
+    }
+}
+
+```
+
+# Motivation
+
+When most of the endpoints in service url are unavailable (but there is at least one available endpoint), creating consumers and producers through PulsarClient will most likely fail. This is an unexpected behavior for Pulsar users since when multiple endpoints are provided, it would be expected that when an endpoint is unavailable, an available endpoint would be used. This behavior is counter-intuitive for users who expect the client to transparently fail over to a working endpoint. To address this, we propose an intelligent feedback mechanism that allows the client to identify, quarantine, and eventually retry unavailable endpoints, ensuring that new connections are routed to healthy brokers whenever possible.
+
+
+# Goals
+Optimize the PulsarClient code logic, remove unavailable serviceUrl endpoints through the feedback mechanism, and improve the success rate of PulsarClient requests.
+
+## In Scope
+- Improve Connection Resilience: Modify the PulsarClient to avoid repeatedly trying to connect to unavailable endpoints.
+- Introduce Endpoint Quarantining: When a connection to an endpoint fails, temporarily remove it from the pool of available endpoints.
+- Implement Exponential Backoff: Re-introduce quarantined endpoints for connection attempts after a dynamically increasing delay, allowing them to recover without overwhelming the system.
+
+# Detailed Design
+We will introduce an endpoint quarantining strategy based on passive feedback from connection attempts.
+**Explanation of nouns:**
+- `availableAddressPool`: a pool containing all available addresses, subset of serviceUrl.
+- `allAddressPool`: a pool containing all addresses in serviceUrl.
+
+By default, the client will only try to connect to endpoints from the availableAddressPool.
+
+- On Connection Failure: If the client fails to connect to an endpoint, it will be temporarily removed from the availableAddressPool and placed into "quarantine".
+- Exponential Backoff: The quarantine duration will increase exponentially upon consecutive failures.
+- On Connection Success: A successful connection to an endpoint proves it is available. If the endpoint was previously failing, its quarantine backoff state will be reset. It will be immediately considered part of the availableAddressPool.
+- Fallback: If the availableAddressPool ever becomes empty, the client will fall back to select endpoint from the allAddressPool by a round-robin approach. This prevents a deadlock where the client cannot connect because all known endpoints are simultaneously in quarantine.
+As [#22934](https://github.com/apache/pulsar/issues/22934#issuecomment-2943690398) mentioned, add `markHostAvailability` method in `ServiceNameResolver` interface like:
+```java
+    /**
+     * Mark the availability of a host.
+     * @param address the host address to mark availability for
+     * @param isAvailable true if the host is available, false otherwise
+     */
+    default void markHostAvailability(InetSocketAddress address, boolean isAvailable){
+        // Default implementation does nothing
+        // Subclass can override this method to implement host availability tracking
+    }
+```
+When resolve one address in serviceUrl, the `ConnectionPool` will invoke `markHostAvailability` to tell availability about that address, so the `ServiceNameResolver` can remove it from `availableAddressPool` if unavailable (or recover back to `availableAddressPool` if available). If all addressed in  `availableAddressPool` are unavailable, the resolver implementation could use a round-robin approach to select address from the `allAddressPool`.
+
+For removed addresses, the quarantine duration will increase exponentially. The quarantine duration can be customized via new optional configurations `serviceUrlQuarantineInitDuration` and `serviceUrlQuarantineMaxDuration` in `ClientBuilder`
+That is to say, assuming that `serviceUrlQuarantineInitDuration` is 1 minute and `serviceUrlQuarantineMaxDuration` is 30 minutes, after host1 is judged as unavailable for the first time, it will be quarantined for 1 minute and then added to `availableAddressPool` again. If it is judged as unavailable again the next time, it will be quarantined for 2 minutes. Similarly, if it is judged as unavailable continuously, the isolation time will be 4 minutes, 8 minutes, 16 minutes, 30 minutes (it reaches serviceUrlQuarantineMaxDuration and no longer increases), 30 minutes... If host1 is determined to be available, the next quarantine duration will be reset to 1 minute.
+
+
+### Usage Example
+```java
+    private void example() throws PulsarClientException {
+        // The failed endpoint will be removed and retried after a period of time, with an initial quarantine duration of 30 seconds increasing exponentially. After reaching the maximum quarantine duration of 1 hour, will be maintained once an hour until a certain succeeds, and the quarantine duration is reset to 0.
+        PulsarClient pulsarClient = PulsarClient.builder()
+                .serviceUrl("pulsar://host1:6650,host2:6650,host3:6650")
+                .serviceUrlQuarantineInitDuration(30000, TimeUnit.MILLISECONDS)
+                .serviceUrlQuarantineMaxDuration(1, TimeUnit.HOURS)
+                .build();    
+
+        // disable removing unavailable serviceUrl endpoints by pass 0 to serviceUrlQuarantineInitDuration and serviceUrlQuarantineMaxDuration
+        PulsarClient pulsarClientDisableReovery = PulsarClient.builder()
+                .serviceUrl("pulsar://host1:6650,host2:6650,host3:6650")
+                .serviceUrlQuarantineInitDuration(0, TimeUnit.MILLISECONDS)
+                .serviceUrlQuarantineMaxDuration(0, TimeUnit.MILLISECONDS)
+                .build();                
+}
+
+```
+## Public-facing Changes
+
+### Public API
+
+1. Add two optional configs `serviceUrlQuarantineInitDuration` and `serviceUrlQuarantineMaxDuration` in `ClientBuilder`
+```java
+    /**
+     * Configure the service URL init quarantine duration.
+     * For single host serviceUrl, this setting has no effect.
+     *
+     * <p>When the client is unable to connect to the a endpint from serviceUrl with multiple hosts, that endpoint
+     *  will be quarantined for a specific duration that is determined in a certain emponential way. 
+     * The init value of a single quarantine duration is set by
+     * @param serviceUrlQuarantineInitDuration. A successful usage of the endpoint will reset the
+     * duration to the initial value and move it back to the available addresses pool.
+     *
+     * <p>
+     * A value of 0 means don't quarantine any endpoints even if they fail.
+     * @param serviceUrlQuarantineInitDuration the initial quarantine duration 
+     * for unavailable endpoint. Defaults to 60 seconds.
+     * @param unit the time unit for the quarantine duration
+     * @return the client builder instance
+     */
+    ClientBuilder serviceUrlQuarantineInitDuration(long serviceUrlQuarantineInitDuration, TimeUnit unit);
+
+    /**
+     * Configure the service URL max quarantine duration.
+     * For single host serviceUrl, this setting has no effect.
+     *
+     * <p>When the client is unable to connect to the a endpint from serviceUrl with multiple hosts, that endpoint 
+     * will be quarantined for a specific duration that is determined in a certain emponential way. 
+     * The max value of a single quarantine duration is set by
+     * @param serviceUrlQuarantineMaxDuration. A successful usage of the endpoint will reset the
+     * duration to the initial value and move it back to the available addresses pool.
+     *
+     * <p>
+     * A value of 0 means don't quarantine any endpoints even if they fail.
+     * @param serviceUrlQuarantineMaxDuration the maximum quarantine duration for 
+     * unavailable endpoint. Defaults to 1 day.
+     * @param unit the time unit for the quarantine duration
+     * @return the client builder instance
+     */
+    ClientBuilder serviceUrlQuarantineMaxDuration(long serviceUrlQuarantineMaxDuration, TimeUnit unit);
+```
+
+# Backward & Forward Compatibility
+You can do upgrading or reverting normally, no specified steps are needed to do.
+
+# Alternatives
+[#22935](https://github.com/apache/pulsar/pull/22935) removes unavailable endpoints through a regular health check mechanism, but this brings new problems (frequent creation of connections and increased system load). So this pip will not use the health check solution.
+
+
+# Links
+
+* Mailing List discussion thread: https://lists.apache.org/thread/44ztyhgm5ly6cljnlbnwrrowmk7jcrkj
+* Mailing List voting thread: 

--- a/pip/pip-427 Align pulsar-admin Default for Mark-Delete Rate with Broker Configuration.md
+++ b/pip/pip-427 Align pulsar-admin Default for Mark-Delete Rate with Broker Configuration.md
@@ -1,0 +1,81 @@
+<!--
+RULES
+* Never place a link to an external site like Google Doc. The proposal should be in this issue entirely.
+* Use a spelling and grammar checker tools if available for you (there are plenty of free ones).
+
+PROPOSAL HEALTH CHECK
+I can read the design document and understand the problem statement and what you plan to change *without* resorting to a couple of hours of code reading just to start having a high level understanding of the change.
+
+IMAGES
+If you need diagrams, avoid attaching large files. You can use [MermaidJS]([url](https://mermaid.js.org/)) as a simple language to describe many types of diagrams.
+
+THIS COMMENTS
+Please remove them when done.
+-->
+
+# PIP-427: Align pulsar-admin Default for Mark-Delete Rate with Broker Configuration
+
+# Motivation
+
+The `pulsar-admin namespaces set-persistence` command allows for the configuration of several persistence-related policies on a namespace. One of these policies is the `mark-delete rate`, controlled by the `--ml-mark-delete-max-rate` (or -r) flag.
+
+The command-line help and its current implementation show that the default value for this flag is 0.0:
+
+```
+-r, --ml-mark-delete-max-rate=<managedLedgerMaxMarkDeleteRate>
+Throttling rate of mark-delete operation (0 means no
+throttle)
+Default: 0.0
+```
+
+Within Pulsar, a managedLedgerMaxMarkDeleteRate of 0 signifies that the rate limit is disabled. This can lead to a "storm" of cursor state writes to BookKeeper, especially with high-frequency acknowledgement patterns, causing significant I/O load, network traffic, and potential cluster instability.
+
+The problem is that if an administrator uses set-persistence to modify another policy (e.g., backlog quotas or ensemble size) and omits the --ml-mark-delete-max-rate flag, the command implicitly applies the default value of 0, thereby disabling any previously configured rate limit. This is a dangerous and counter-intuitive side effect.
+
+A user intending to change one policy can inadvertently disable a critical throttling mechanism, leading to unexpected performance degradation. The broker itself has a safe default (managedLedgerMaxMarkDeleteRate = 1.0), and the admin tool should align with this principle.
+
+# Goals
+
+The goal of this PIP is to change the behavior of the pulsar-admin namespaces set-persistence command.
+
+When set-persistence is invoked, if the `--ml-mark-delete-max-rate` flag is not provided by the user, the command should not reset the mark-delete rate to `0`. Instead, the broker should apply the default rate limit configured at the broker level (via the `managedLedgerMaxMarkDeleteRate` parameter in `broker.conf`).
+
+This change ensures that the command has a safe, predictable default. Users who explicitly wish to disable the rate limit must do so intentionally by providing `--ml-mark-delete-max-rate 0`.
+
+# Proposed Changes
+
+The implementation will require modifications to how the set-persistence command and its corresponding REST endpoint handle the PersistencePolicies object.
+
+1. pulsar-admin CLI Tool:
+
+- The command definition for set-persistence (in CmdNamespaces.java) will be changed. The `--ml-mark-delete-max-rate` parameter's default will be modified from 0.0 to a value indicating it is "unset" (e.g., null or a negative value like -1).
+
+2. Broker Admin REST API:
+
+- The REST endpoint for setting persistence policies (in the Namespaces resource class) will be updated. When it receives the PersistencePolicies payload, it will check if managedLedgerMaxMarkDeleteRate has the "unset" value.
+  - The logic will be as follows:
+    - If the payload contains an explicit value for managedLedgerMaxMarkDeleteRate (including 0.0), the broker will use that value. This preserves the existing ability to set any specific rate.
+    - If the rate is "unset" in the payload, the broker will fetch the default value from its own service configuration (ServiceConfiguration.getManagedLedgerMaxMarkDeleteRate()) and apply that to the namespace's persistence policy.
+This makes the broker the source of truth for the default value and prevents accidental resets of the policy.
+
+# Backward & Forward Compatibility
+
+This change introduces a behavioral modification that is considered a bug fix for unsafe default behavior.
+
+- Backward Compatibility: Scripts that used pulsar-admin namespaces set-persistence to update other policies (e.g., --backlog-quota-limit-size) and implicitly relied on it to reset the mark-delete rate to 0 will now see the broker's default rate limit (e.g., 1.0) applied instead. This is the desired outcome. To retain the old behavior of disabling the limit, these scripts must be updated to be explicit: pulsar-admin ... set-persistence --ml-mark-delete-max-rate 0. This change makes a potentially harmful action explicit and intentional.
+- Forward Compatibility: No issues are expected. Clusters running the new code will correctly interpret API calls from older clients, as the existing logic for explicitly set values remains unchanged.
+
+And the change will not affect any existing namespaces.
+
+# Alternatives
+
+- Hardcode the CLI default to 1.0: This was rejected because it does not respect a custom default that an administrator may have configured in broker.conf. The broker must be the single source of truth for its default configuration.
+- Only update the documentation: This was rejected because it leaves a non-intuitive and potentially harmful default behavior in place for a powerful, multi-purpose command. The principle of least surprise dictates that the tool's behavior should be made safer.
+
+# Links
+
+<!--
+Updated afterwards
+-->
+* Mailing List discussion thread: https://lists.apache.org/thread/j9vx6zkkgnz08sfgp14swylb8wv6djzs
+* Mailing List voting thread:

--- a/pip/pip-428.md
+++ b/pip/pip-428.md
@@ -1,0 +1,301 @@
+# PIP-428: Change TopicPoliciesService interface to fix consistency issues
+
+# Background knowledge
+
+Apache Pulsar's topic policies provide a way to configure topic-specific settings that override namespace-level policies. These policies are stored in system topics (specifically in the `__change_events` topic) and are managed by the `TopicPoliciesService`.
+It's possible to have a third-party implementation of `TopicPoliciesService`, and since the interface is public, this PIP is needed to change the interface, which is required to fix the consistency issues.
+
+**Key concepts:**
+- **Topic Policies**: Configuration settings specific to a topic (e.g., retention, backlog quotas, dispatch rates)
+- **System Topics**: Special topics used internally by Pulsar to store metadata and configurations
+- **TopicPoliciesService**: The service responsible for reading, writing, and caching topic policies
+- **PulsarEvent**: The event format used to store topic policy changes in system topics
+
+The current implementation has several issues:
+
+1. **Thread Safety**: Topic policies are cached, and these cached instances are mutable in a non-thread-safe way
+2. **Race Conditions**: When multiple policy updates are made in quick succession, they can overwrite each other
+3. **Consistency Issues**: The lack of proper synchronization can lead to corrupted or lost policy updates
+
+Example test code that demonstrates a lost update:
+
+```java
+    @Test
+    public void testMultipleUpdates() throws Exception {
+        String topic = "persistent://my-tenant/my-namespace/testtopic";
+        admin.topics().createNonPartitionedTopic(topic);
+
+        InactiveTopicPolicies inactiveTopicPolicies = new InactiveTopicPolicies();
+        inactiveTopicPolicies.setDeleteWhileInactive(true);
+        inactiveTopicPolicies.setInactiveTopicDeleteMode(InactiveTopicDeleteMode.delete_when_subscriptions_caught_up);
+        inactiveTopicPolicies.setMaxInactiveDurationSeconds(3600);
+        admin.topicPolicies().setInactiveTopicPolicies(topic, inactiveTopicPolicies);
+
+        DispatchRate dispatchRate = DispatchRate
+                .builder()
+                .dispatchThrottlingRateInMsg(1000)
+                .dispatchThrottlingRateInByte(1000000)
+                .build();
+        admin.topicPolicies().setReplicatorDispatchRate(topic, dispatchRate);
+
+        String clusterId = "test";
+        admin.topics().setReplicationClusters(topic, List.of(clusterId));
+
+        // wait for 1 second
+        Thread.sleep(1000);
+
+        // the first assertion fails
+        assertEquals(admin.topicPolicies().getInactiveTopicPolicies(topic), inactiveTopicPolicies);
+        assertEquals(admin.topicPolicies().getReplicatorDispatchRate(topic), dispatchRate);
+        assertEquals(admin.topics().getReplicationClusters(topic, true), Set.of(clusterId));
+    }
+
+```
+
+# Motivation
+
+The current topic policies implementation suffers from critical issues that affect production systems:
+
+1. **Data Corruption**: When multiple topic policies are updated within a short time window, some updates may be lost or corrupted. For example, setting replication clusters followed immediately by inactive topic policies can result in the replication clusters being null or incomplete.
+
+2. **Race Conditions**: The current implementation retrieves the entire TopicPolicies object, modifies it, and writes it back. Without proper synchronization, concurrent updates can overwrite each other's changes.
+
+3. **Thread Safety**: Unlike namespace policies (which were fixed in #9711), topic policies are still mutable and shared across threads without proper synchronization, leading to potential data corruption.
+
+4. **Poor Developer Experience**: Developers must add artificial delays between policy updates to work around these issues, which is error-prone and impacts performance.
+
+These issues have been reported multiple times (#24393, #21303) and affect production deployments where automated policy management is common.
+
+# Goals
+
+## In Scope
+
+- Implement thread-safe topic policy updates that prevent data corruption
+- Ensure sequential policy updates are processed correctly without requiring artificial delays
+- Provide atomic update operations that modify only the specific policy fields being changed
+- Maintain backward compatibility with existing TopicPoliciesService consumers
+- Implement proper synchronization for concurrent policy updates
+- Add read-your-writes consistency guarantees for policy updates
+
+## Out of Scope
+
+- Changing the underlying storage mechanism for topic policies (system topics)
+- Modifying the wire protocol or client APIs
+- Implementing transactional updates across multiple topics
+- Changing how policies are inherited from namespace to topic level
+
+# High Level Design
+
+The solution introduces several key changes to ensure thread-safe and consistent topic policy updates:
+
+1. **Immutable TopicPolicies Objects**: Similar to the namespace policies fix, TopicPolicies instances will be made effectively immutable by:
+   - Adding a `clone()` method to TopicPolicies and all nested policy objects
+   - Never modifying cached/shared instances directly
+   - Always working with cloned copies when updates are needed
+
+2. **Functional Update API**: Replace the current "get-modify-set" pattern with a functional update approach:
+   ```java
+   CompletableFuture<Void> updateTopicPoliciesAsync(
+       TopicName topicName,
+       boolean isGlobalPolicy,
+       boolean skipUpdateWhenTopicPolicyDoesntExist,
+       Consumer<TopicPolicies> policyUpdater
+   );
+   ```
+   This ensures that updates are applied atomically to a cloned copy of the current policies.
+
+3. **Sequential Update Guarantees**: Implement a sequencer mechanism that ensures updates for the same topic and policy type (global/local) are processed in order:
+   - Each topic+policyType combination has its own update queue in the form of chained CompletableFutures
+   - Updates are chained using CompletableFutures to maintain order
+   - The queue is cleaned up when no updates are pending
+
+4. **Read-Your-Writes Consistency**: Ensure that policy updates don't complete until they have been read by the system topic reader:
+   - Track message IDs of policy updates
+   - Wait for the reader to process each update before completing the operation
+   - This prevents the race condition where subsequent reads might not see recent updates
+
+# Detailed Design
+
+## Design & Implementation Details
+
+### 1. TopicPolicies Cloning
+
+All policy objects will implement `Cloneable` and provide proper deep cloning:
+
+```java
+public class TopicPolicies implements Cloneable {
+    @Override
+    public TopicPolicies clone() {
+        TopicPolicies cloned = (TopicPolicies) super.clone();
+        // Deep clone all mutable fields
+        if (this.backLogQuotaMap != null) {
+            cloned.backLogQuotaMap = new HashMap<>();
+            for (Map.Entry<String, BacklogQuotaImpl> entry : this.backLogQuotaMap.entrySet()) {
+                cloned.backLogQuotaMap.put(entry.getKey(), 
+                    entry.getValue() != null ? entry.getValue().clone() : null);
+            }
+        }
+        // ... clone other fields
+        return cloned;
+    }
+}
+```
+
+### 2. Update Sequencer
+
+The sequencer ensures updates are processed in order:
+
+```java
+private final ConcurrentHashMap<Pair<TopicName, Boolean>, CompletableFuture<Void>> 
+    topicPolicyUpdateSequencer = new ConcurrentHashMap<>();
+
+private CompletableFuture<Void> updateTopicPoliciesAsync(...) {
+    Pair<TopicName, Boolean> sequencerKey = Pair.of(topicName, isGlobalPolicy);
+    
+    return topicPolicyUpdateSequencer.compute(sequencerKey, (key, existingFuture) -> {
+        CompletableFuture<Void> chain = (existingFuture == null || existingFuture.isDone())
+            ? CompletableFuture.completedFuture(null)
+            : existingFuture;
+            
+        return chain.thenCompose(v -> performUpdate(...));
+    });
+}
+```
+
+### 3. Message Tracking for Consistency
+
+Track when policy updates have been processed by the reader:
+
+```java
+private static class TopicPolicyMessageHandlerTracker {
+    private List<MessageIdAdv> lastHandledMessageIds = new ArrayList<>();
+    private List<PriorityQueue<PendingMessageFuture>> pendingFutures = new ArrayList<>();
+    
+    public synchronized void handleMessageId(MessageIdAdv messageId) {
+        // Update last handled message ID
+        // Complete any pending futures for messages up to this ID
+    }
+    
+    public synchronized void addPendingFuture(MessageIdAdv messageId, CompletableFuture<Void> future) {
+        // Add future to wait for this message ID to be processed
+    }
+}
+```
+
+### 4. Updated Admin API Usage
+
+The admin API implementations will be updated to use the new functional approach:
+
+```java
+// Before:
+TopicPolicies policies = getTopicPolicies(topicName);
+policies.setMaxConsumerPerTopic(maxConsumers);
+updateTopicPoliciesAsync(topicName, policies);
+
+// After:
+updateTopicPoliciesAsync(topicName, isGlobal, false, policies -> {
+    policies.setMaxConsumerPerTopic(maxConsumers);
+});
+```
+
+## Public-facing Changes
+
+### Public API
+
+The main change is to the `TopicPoliciesService` interface:
+
+```java
+public interface TopicPoliciesService {
+    //...
+    /**
+     * Update policies for a topic asynchronously.
+     * The policyUpdater will be called with a TopicPolicies object 
+     * (either newly created or cloned from existing) which can be safely mutated.
+     *
+     * @param topicName       topic name
+     * @param isGlobalPolicy  true if updating global policy, false for local
+     * @param skipUpdateWhenTopicPolicyDoesntExist when true, skips the update if the topic policy does not already
+     *                                             exist. This is useful for cases when the policyUpdater is removing
+     *                                             a setting in the policy.
+     * @param policyUpdater   a function that modifies the TopicPolicies
+     * @return a CompletableFuture that completes when the update has been 
+     *         processed with read-your-writes consistency
+     */
+    CompletableFuture<Void> updateTopicPoliciesAsync(
+        TopicName topicName,
+        boolean isGlobalPolicy,
+        boolean skipUpdateWhenTopicPolicyDoesntExist,
+        Consumer<TopicPolicies> policyUpdater
+    );
+   //...
+}
+```
+
+The previous method signature
+`CompletableFuture<Void> updateTopicPoliciesAsync(TopicName topicName, TopicPolicies policies)` has been removed since
+it's not possible to guarantee thread safety and consistency when the complete `TopicPolicies` object is mutated at
+once.
+In the changed method, the `policyUpdater` function receives a cloned instance of the current policies, which can be
+safely modified, applying only a specific change.
+The `skipUpdateWhenTopicPolicyDoesntExist` parameter allows skipping the update if the topic policy does not exist. This
+is useful when removing or nullifying specific policy settings where creating a new policy is unnecessary if one doesn't
+already exist.
+
+An example of this case can be seen in many of the remove methods.
+```java
+    // skipUpdateWhenTopicPolicyDoesntExist is set to true when removing max producers
+    protected CompletableFuture<Void> internalRemoveMaxProducers(boolean isGlobal) {
+        return pulsar().getTopicPoliciesService().updateTopicPoliciesAsync(topicName, isGlobal, true, policies -> {
+            policies.setMaxProducerPerTopic(null);
+        });
+    }
+    
+    // skipUpdateWhenTopicPolicyDoesntExist is set to true when offloadPoliciesToSet is null    
+    protected CompletableFuture<Void> internalSetOffloadPolicies(OffloadPoliciesImpl offloadPoliciesToSet,
+                                                                boolean isGlobal) {
+        return pulsar().getTopicPoliciesService()
+              .updateTopicPoliciesAsync(topicName, isGlobal, offloadPoliciesToSet == null, policies -> {
+                 policies.setOffloadPolicies(offloadPoliciesToSet);
+              });
+    }
+```
+
+## Security Considerations
+
+This change does not introduce new security concerns:
+
+- The update mechanism respects existing authorization checks
+- No new APIs or endpoints are exposed
+- The functional update pattern actually improves security by preventing accidental policy corruption
+
+## Backward & Forward Compatibility
+
+- The change is backward compatible as it's internal to the broker
+- No special upgrade steps required
+
+## Alternatives
+
+### Pessimistic Locking: Use distributed locks for each topic's policies
+
+Rejected: Would add significant latency and complexity
+
+### Transactional Updates: Implement full ACID transactions for policy updates
+
+Rejected: Overkill for this use case and would require major architectural changes
+
+### Client-side Retries: Document the issue and require clients to implement retry logic
+
+Rejected: Poor developer experience and doesn't fix the root cause
+
+### Optimistic Concurrency Control: Use version numbers for policies
+
+Rejected: Would break existing client APIs and require significant changes
+
+## General Notes
+
+This fix follows somewhat the same pattern successfully used for namespace policies in #9711. However, the major difference is that topic policies use system topics for persistence, and there aren't similar ways to achieve consistency.
+
+## Links
+
+- Mailing List discussion thread: https://lists.apache.org/thread/dk5lks30hkxj2fl8nqrcds9f5j7hryfl
+- Mailing List voting thread: https://lists.apache.org/thread/ndh0dhfjqf1htcmodgyyqt6k4bgdfj3x

--- a/pom.xml
+++ b/pom.xml
@@ -289,7 +289,7 @@ flexible messaging model and an intuitive client API.</description>
     <apache-http-client.version>4.5.13</apache-http-client.version>
     <apache-httpcomponents.version>4.4.15</apache-httpcomponents.version>
     <jetcd.version>0.7.7</jetcd.version>
-    <oxia.version>0.5.0</oxia.version>
+    <oxia.version>0.6.0</oxia.version>
     <snakeyaml.version>2.0</snakeyaml.version>
     <ant.version>1.10.12</ant.version>
     <seancfoley.ipaddress.version>5.5.0</seancfoley.ipaddress.version>
@@ -1335,12 +1335,12 @@ flexible messaging model and an intuitive client API.</description>
       </dependency>
 
       <dependency>
-        <groupId>io.streamnative.oxia</groupId>
+        <groupId>io.github.oxia-db</groupId>
         <artifactId>oxia-client</artifactId>
         <version>${oxia.version}</version>
       </dependency>
       <dependency>
-        <groupId>io.streamnative.oxia</groupId>
+        <groupId>io.github.oxia-db</groupId>
         <artifactId>oxia-testcontainers</artifactId>
         <version>${oxia.version}</version>
       </dependency>

--- a/pulsar-broker/pom.xml
+++ b/pulsar-broker/pom.xml
@@ -182,7 +182,7 @@
     </dependency>
 
     <dependency>
-      <groupId>io.streamnative.oxia</groupId>
+      <groupId>io.github.oxia-db</groupId>
       <artifactId>oxia-testcontainers</artifactId>
       <scope>test</scope>
     </dependency>

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/impl/PersistentTopicsBase.java
@@ -5493,4 +5493,132 @@ public class PersistentTopicsBase extends AdminResource {
                             return null;
                         }));
     }
+
+    protected CompletableFuture<MessageId> internalGetMessageIDByIndexAsync(Long index, boolean authoritative) {
+        if (!pulsar().getBrokerService().isBrokerEntryMetadataEnabled()) {
+            return FutureUtil.failedFuture(new RestException(Status.PRECONDITION_FAILED,
+                    "GetMessageIDByIndex is not allowed when broker entry metadata is disabled"));
+        }
+        if (index == null || index < 0) {
+            return FutureUtil.failedFuture(new RestException(Status.NOT_FOUND,
+                    "Invalid message index: " + index));
+        }
+        int partitionIndex = topicName.getPartitionIndex();
+        CompletableFuture<Void> future = validateTopicOperationAsync(topicName, TopicOperation.PEEK_MESSAGES);
+        return future.thenCompose(__ -> {
+                    if (topicName.isGlobal()) {
+                        return validateGlobalNamespaceOwnershipAsync(namespaceName);
+                    } else {
+                        return CompletableFuture.completedFuture(null);
+                    }
+                }).thenCompose(__ -> {
+                    if (topicName.isPartitioned()) {
+                        return CompletableFuture.completedFuture(null);
+                    } else {
+                        return getPartitionedTopicMetadataAsync(topicName, authoritative, false)
+                                .thenAccept(topicMetadata -> {
+                                    if (topicMetadata.partitions > 0) {
+                                        log.warn("[{}] Not supported getMessageIdByIndex operation on "
+                                                        + "partitioned-topic {}", clientAppId(), topicName);
+                                        throw new RestException(Status.METHOD_NOT_ALLOWED,
+                                                "GetMessageIDByIndex is not allowed on partitioned-topic");
+                                    }
+                                });
+                    }
+                }).thenCompose(ignore -> validateTopicOwnershipAsync(topicName, authoritative))
+                .thenCompose(__ -> getTopicReferenceAsync(topicName))
+                .thenCompose(topic -> {
+                    if (!(topic instanceof PersistentTopic persistentTopic)) {
+                        log.error("[{}] Get message id by index on a non-persistent topic {} is not allowed",
+                                clientAppId(), topicName);
+                        return FutureUtil.failedFuture(new RestException(Status.METHOD_NOT_ALLOWED,
+                                "Get message id by index on a non-persistent topic is not allowed"));
+                    }
+                    ManagedLedger managedLedger = persistentTopic.getManagedLedger();
+                    Position lastPosition = managedLedger.getLastConfirmedEntry();
+                    Position firstPosition = managedLedger.getFirstPosition();
+                    if (firstPosition == null || lastPosition == null || firstPosition.equals(lastPosition)) {
+                        return FutureUtil.failedFuture(new RestException(Status.NOT_FOUND,
+                                "No messages found in topic " + topicName));
+                    }
+                    return findMessageIndexByPosition(
+                            PositionFactory.create(firstPosition.getLedgerId(), 0),
+                            managedLedger)
+                            .thenCompose(firstIndex -> {
+                                if (index < firstIndex) {
+                                    return CompletableFuture.completedFuture(PositionFactory.EARLIEST);
+                                } else {
+                                    return managedLedger.asyncFindPosition(entry -> {
+                                        try {
+                                            Long messageIndex = getIndexFromEntry(entry);
+                                            if (messageIndex == null) {
+                                                return false; // Skip messages without index
+                                            } else {
+                                                // If the message index is less than the requested index,
+                                                // we continue searching
+                                                return messageIndex < index;
+                                            }
+                                        } catch (Throwable e) {
+                                            log.error("Error deserialize message for message position find", e);
+                                            return false;
+                                        } finally {
+                                            entry.release();
+                                        }
+                                    });
+                                }
+                            }).thenCompose(position -> {
+                                if (position.compareTo(lastPosition) > 0) {
+                                    return FutureUtil.failedFuture(new RestException(Status.NOT_FOUND,
+                                            "Message not found for index " + index));
+                                } else {
+                                    return CompletableFuture.completedFuture(position);
+                                }
+                            });
+                }).thenCompose(position -> CompletableFuture.completedFuture(
+                        new MessageIdImpl(position.getLedgerId(), position.getEntryId(), partitionIndex)));
+    }
+
+    protected CompletableFuture<Long> findMessageIndexByPosition(Position position, ManagedLedger managedLedger) {
+        CompletableFuture<Long> indexFuture = new CompletableFuture<>();
+        managedLedger.asyncReadEntry(position, new AsyncCallbacks.ReadEntryCallback() {
+            @Override
+            public void readEntryComplete(Entry entry, Object ctx) {
+                try {
+                    Long index = getIndexFromEntry(entry);
+                    if (index == null) {
+                        indexFuture.completeExceptionally(new RestException(Status.PRECONDITION_FAILED,
+                                "Broker entry metadata is not present in the message"));
+                    } else if (index < 0) {
+                        indexFuture.completeExceptionally(new RestException(Status.PRECONDITION_FAILED,
+                                "Invalid message index: " + index));
+                    } else {
+                        indexFuture.complete(index);
+                    }
+                } catch (Throwable e) {
+                    indexFuture.completeExceptionally(new RestException(Status.INTERNAL_SERVER_ERROR,
+                            "Failed to get index from entry: " + e.getMessage()));
+                } finally {
+                    entry.release();
+                }
+            }
+
+            @Override
+            public void readEntryFailed(ManagedLedgerException exception, Object ctx) {
+                log.error("[{}] Failed to read position {} on topic {}",
+                        clientAppId(), position, topicName, exception);
+                indexFuture.completeExceptionally(exception);
+            }
+        }, null);
+        return indexFuture;
+    }
+
+
+    private static Long getIndexFromEntry(Entry entry) {
+        final var brokerEntryMetadata = Commands.parseBrokerEntryMetadataIfExist(entry.getDataBuffer());
+        if (brokerEntryMetadata != null && brokerEntryMetadata.hasIndex()) {
+            return brokerEntryMetadata.getIndex();
+        } else {
+            return null;
+        }
+    }
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -5073,7 +5073,7 @@ public class PersistentTopics extends PersistentTopicsBase {
                 .thenAccept(asyncResponse::resume)
                 .exceptionally(ex -> {
                     if (!isRedirectException(ex)) {
-                        log.error("[{}] Failed to get message id by index for topic {}, partition id {}, index {}",
+                        log.error("[{}] Failed to get message id by index for topic {}, index {}",
                                 clientAppId(), topicName, index, ex);
                     }
                     resumeAsyncResponseExceptionally(asyncResponse, ex);

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/admin/v2/PersistentTopics.java
@@ -5048,5 +5048,38 @@ public class PersistentTopics extends PersistentTopicsBase {
                 });
     }
 
+    @GET
+    @Path("/{tenant}/{namespace}/{topic}/getMessageIdByIndex")
+    @ApiOperation(hidden = true, value = "Get Message ID by index.",
+            notes = "If the specified index is a system message, "
+                    + "it will return the message id of the later message.")
+    @ApiResponses(value = {
+            @ApiResponse(code = 307, message = "Current broker doesn't serve the namespace of this topic"),
+            @ApiResponse(code = 403, message = "Don't have admin permission"),
+            @ApiResponse(code = 404, message = "Namespace or partitioned topic does not exist, "
+                    + "or the index is invalid"),
+            @ApiResponse(code = 406, message = "The topic is not a persistent topic"),
+            @ApiResponse(code = 412, message = "The broker is not enable broker entry metadata"),
+    })
+    public void getMessageIDByIndex(@Suspended final AsyncResponse asyncResponse,
+                                    @PathParam("tenant") String tenant,
+                                    @PathParam("namespace") String namespace,
+                                    @PathParam("topic") @Encoded String encodedTopic,
+                                    @QueryParam("index") long index,
+                                    @QueryParam("authoritative") @DefaultValue("false")
+                                                   boolean authoritative){
+        validateTopicName(tenant, namespace, encodedTopic);
+        internalGetMessageIDByIndexAsync(index, authoritative)
+                .thenAccept(asyncResponse::resume)
+                .exceptionally(ex -> {
+                    if (!isRedirectException(ex)) {
+                        log.error("[{}] Failed to get message id by index for topic {}, partition id {}, index {}",
+                                clientAppId(), topicName, index, ex);
+                    }
+                    resumeAsyncResponseExceptionally(asyncResponse, ex);
+                    return null;
+                });
+    }
+
     private static final Logger log = LoggerFactory.getLogger(PersistentTopics.class);
 }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -220,6 +220,10 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
             // Reset to initial state
             highestDeliveryTimeTracked = 0;
             messagesHaveFixedDelay = true;
+            if (delayedMessagesCount.get() != 0) {
+                log.warn("[{}] Delayed message tracker is empty, but delayedMessagesCount is {}",
+                        dispatcher.getName(), delayedMessagesCount.get());
+            }
         }
 
         updateTimer();

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/delayed/InMemoryDelayedDeliveryTracker.java
@@ -30,6 +30,7 @@ import java.time.Clock;
 import java.util.NavigableSet;
 import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
@@ -63,6 +64,9 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
 
     // The bit count to trim to reduce memory occupation.
     private final int timestampPrecisionBitCnt;
+
+    // Count of delayed messages in the tracker.
+    private final AtomicLong delayedMessagesCount = new AtomicLong(0);
 
     InMemoryDelayedDeliveryTracker(AbstractPersistentDispatcherMultipleConsumers dispatcher, Timer timer,
                                    long tickTimeMillis,
@@ -125,6 +129,8 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
         delayedMessageMap.computeIfAbsent(timestamp, k -> new Long2ObjectRBTreeMap<>())
                 .computeIfAbsent(ledgerId, k -> new Roaring64Bitmap())
                 .add(entryId);
+        delayedMessagesCount.incrementAndGet();
+
         updateTimer();
 
         checkAndUpdateHighest(deliverAt);
@@ -183,6 +189,7 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
                         positions.add(PositionFactory.create(ledgerId, entryId));
                     });
                     n -= cardinality;
+                    delayedMessagesCount.addAndGet(-cardinality);
                     ledgerIdToDelete.add(ledgerId);
                 } else {
                     long[] entryIdsArray = entryIds.toArray();
@@ -190,6 +197,7 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
                         positions.add(PositionFactory.create(ledgerId, entryIdsArray[i]));
                         entryIds.removeLong(entryIdsArray[i]);
                     }
+                    delayedMessagesCount.addAndGet(-n);
                     n = 0;
                 }
                 if (n <= 0) {
@@ -221,14 +229,13 @@ public class InMemoryDelayedDeliveryTracker extends AbstractDelayedDeliveryTrack
     @Override
     public CompletableFuture<Void> clear() {
         this.delayedMessageMap.clear();
+        this.delayedMessagesCount.set(0);
         return CompletableFuture.completedFuture(null);
     }
 
     @Override
     public long getNumberOfDelayedMessages() {
-        return delayedMessageMap.values().stream().mapToLong(
-                ledgerMap -> ledgerMap.values().stream().mapToLong(
-                        Roaring64Bitmap::getLongCardinality).sum()).sum();
+        return delayedMessagesCount.get();
     }
 
     /**

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/namespace/NamespaceService.java
@@ -1274,13 +1274,16 @@ public class NamespaceService implements AutoCloseable {
     }
 
     public CompletableFuture<Boolean> checkTopicOwnership(TopicName topicName) {
-        // TODO: Add unit tests cover it.
+        return getBundleAsync(topicName).thenCompose(bundle -> checkBundleOwnership(topicName, bundle));
+    }
+
+    public CompletableFuture<Boolean> checkBundleOwnership(TopicName topicName, NamespaceBundle bundle) {
         if (ExtensibleLoadManagerImpl.isLoadManagerExtensionEnabled(pulsar)) {
-            return getBundleAsync(topicName)
-                    .thenCompose(bundle -> loadManager.get().checkOwnershipAsync(Optional.of(topicName), bundle));
+            // TODO: Add unit tests cover it.
+            return loadManager.get().checkOwnershipAsync(Optional.of(topicName), bundle);
+        } else {
+            return ownershipCache.checkOwnershipAsync(bundle);
         }
-        return getBundleAsync(topicName)
-                .thenCompose(ownershipCache::checkOwnershipAsync);
     }
 
     public CompletableFuture<Void> removeOwnedServiceUnitAsync(NamespaceBundle nsBundle) {

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/BrokerService.java
@@ -2364,19 +2364,19 @@ public class BrokerService implements Closeable {
 
     public CompletableFuture<Void> checkTopicNsOwnership(final String topic) {
         TopicName topicName = TopicName.get(topic);
+        final var namespaceService = pulsar.getNamespaceService();
 
-        return pulsar.getNamespaceService().checkTopicOwnership(topicName)
-                .thenCompose(ownedByThisInstance -> {
+        return namespaceService.getBundleAsync(topicName).thenCompose(bundle ->
+                namespaceService.checkBundleOwnership(topicName, bundle).thenCompose(ownedByThisInstance -> {
                     if (ownedByThisInstance) {
                         return CompletableFuture.completedFuture(null);
                     } else {
-                        String msg = String.format("Namespace bundle for topic (%s) not served by this instance:%s. "
-                                        + "Please redo the lookup. Request is denied: namespace=%s",
-                                topic, pulsar.getBrokerId(), topicName.getNamespace());
+                        String msg = String.format("Namespace bundle (%s) for topic (%s) not served by this instance:"
+                                + "%s. Please redo the lookup.", bundle, topic, pulsar.getBrokerId());
                         log.warn(msg);
                         return FutureUtil.failedFuture(new ServiceUnitNotReadyException(msg));
                     }
-                });
+                }));
     }
 
     public CompletableFuture<Integer> unloadServiceUnit(NamespaceBundle serviceUnit,

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -101,8 +101,10 @@ public class Consumer {
     private final LongAdder messageAckCounter;
     private final Rate messageAckRate;
 
+    private volatile long firstMessagesSentTimestamp;
     private volatile long lastConsumedTimestamp;
     private volatile long lastAckedTimestamp;
+    private volatile long firstConsumedFlowTimestamp;
     private volatile long lastConsumedFlowTimestamp;
     private Rate chunkedMessageRate;
 
@@ -432,6 +434,9 @@ public class Consumer {
         writeAndFlushPromise.addListener(status -> {
             // only increment counters after the messages have been successfully written to the TCP/IP connection
             if (status.isSuccess()) {
+                if (firstMessagesSentTimestamp == 0) {
+                    firstMessagesSentTimestamp =  System.currentTimeMillis();
+                }
                 msgOut.recordMultipleEvents(totalMessages, totalBytes);
                 msgOutCounter.add(totalMessages);
                 bytesOutCounter.add(totalBytes);
@@ -839,7 +844,11 @@ public class Consumer {
 
     public void flowPermits(int additionalNumberOfMessages) {
         checkArgument(additionalNumberOfMessages > 0);
-        this.lastConsumedFlowTimestamp = System.currentTimeMillis();
+        final long currentTs = System.currentTimeMillis();
+        if (firstConsumedFlowTimestamp == 0) {
+            firstConsumedFlowTimestamp  = currentTs;
+        }
+        this.lastConsumedFlowTimestamp = currentTs;
 
         // block shared consumer when unacked-messages reaches limit
         if (shouldBlockConsumerOnUnackMsgs() && unackedMessages >= getMaxUnackedMessages()) {
@@ -974,6 +983,8 @@ public class Consumer {
         stats.lastAckedTimestamp = lastAckedTimestamp;
         stats.lastConsumedTimestamp = lastConsumedTimestamp;
         stats.lastConsumedFlowTimestamp = lastConsumedFlowTimestamp;
+        stats.firstMessagesSentTimestamp = firstMessagesSentTimestamp;
+        stats.firstConsumedFlowTimestamp = firstConsumedFlowTimestamp;
         stats.availablePermits = getAvailablePermits();
         stats.unackedMessages = unackedMessages;
         stats.blockedConsumerOnUnackedMsgs = blockedConsumerOnUnackedMsgs;

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/Consumer.java
@@ -754,7 +754,7 @@ public class Consumer {
 
     private void checkAckValidationError(CommandAck ack, Position position) {
         if (ack.hasValidationError()) {
-            log.error("[{}] [{}] Received ack for corrupted message at {} - Reason: {}", subscription,
+            log.warn("[{}] [{}] Received ack for corrupted message at {} - Reason: {}", subscription,
                     consumerId, position, ack.getValidationError());
         }
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentMessageExpiryMonitor.java
@@ -173,6 +173,10 @@ public class PersistentMessageExpiryMonitor implements FindEntryCallback, Messag
         return msgExpired.getRate();
     }
 
+    public long getMessageExpiryCount() {
+        return msgExpired.getCount();
+    }
+
     public long getTotalMessageExpired() {
         return totalMsgExpired.sum();
     }

--- a/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
+++ b/pulsar-broker/src/main/java/org/apache/pulsar/broker/service/persistent/PersistentSubscription.java
@@ -1348,6 +1348,7 @@ public class PersistentSubscription extends AbstractSubscription {
         }
         subStats.msgBacklogNoDelayed = subStats.msgBacklog - subStats.msgDelayed;
         subStats.msgRateExpired = expiryMonitor.getMessageExpiryRate();
+        subStats.msgExpired = expiryMonitor.getMessageExpiryCount();
         subStats.totalMsgExpired = expiryMonitor.getTotalMessageExpired();
         subStats.isReplicated = isReplicated();
         subStats.subscriptionProperties = subscriptionProperties;

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/admin/AdminApi2Test.java
@@ -1444,7 +1444,7 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
     }
 
     @Test(timeOut = 30000)
-    public void testConsumerStatsLastTimestamp() throws PulsarClientException, PulsarAdminException, InterruptedException {
+    public void testConsumerStatsTimestamps() throws PulsarClientException, PulsarAdminException, InterruptedException {
         long timestamp = System.currentTimeMillis();
         final String topicName = "consumer-stats-" + timestamp;
         final String subscribeName = topicName + "-test-stats-sub";
@@ -1505,6 +1505,9 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         consumerStats = subscriptionStats.getConsumers().get(0);
         long consumedTimestamp = consumerStats.getLastConsumedTimestamp();
         long ackedTimestamp = consumerStats.getLastAckedTimestamp();
+        final long firstMessagesSentTimestamp = consumerStats.getFirstMessagesSentTimestamp();
+        final long firstConsumedFlowTimestamp = consumerStats.getFirstConsumedFlowTimestamp();
+
 
         // The lastConsumedTimestamp should same as the last time because the broker does not push any messages and the
         // consumer does not pull any messages.
@@ -1512,6 +1515,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         assertTrue(startAckedTimestampInConsumerStats < ackedTimestamp);
         assertNotEquals(0, consumedFlowTimestamp);
         assertTrue(startAckedTimestampInSubStats < ackedTimestampInSubStats);
+        assertNotEquals(0, firstConsumedFlowTimestamp);
+        assertNotEquals(0, firstMessagesSentTimestamp);
 
         // d. Send another messages. The lastConsumedTimestamp should be updated.
         producer.send("message-2".getBytes(StandardCharsets.UTF_8));
@@ -1537,6 +1542,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         consumerStats = subscriptionStats.getConsumers().get(0);
         long lastConsumedTimestamp = consumerStats.getLastConsumedTimestamp();
         long lastAckedTimestamp = consumerStats.getLastAckedTimestamp();
+        final long firstMessageSentTimestamp2 = consumerStats.getFirstMessagesSentTimestamp();
+        final long firstConsumedFlowTimestamp2 = consumerStats.getFirstConsumedFlowTimestamp();
 
         assertTrue(consumedTimestamp < lastConsumedTimestamp);
         assertTrue(ackedTimestamp < lastAckedTimestamp);
@@ -1544,6 +1551,8 @@ public class AdminApi2Test extends MockedPulsarServiceBaseTest {
         assertEquals(lastConsumedFlowTimestamp, consumedFlowTimestamp);
         assertTrue(ackedTimestampInSubStats < lastAckedTimestampInSubStats);
         assertEquals(lastConsumedTimestamp, lastConsumedTimestampInSubStats);
+        assertEquals(firstConsumedFlowTimestamp, firstConsumedFlowTimestamp2);
+        assertEquals(firstMessagesSentTimestamp, firstMessageSentTimestamp2);
 
         consumer.close();
         producer.close();

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/BrokerEntryMetadataE2ETest.java
@@ -19,26 +19,32 @@
 package org.apache.pulsar.broker.service;
 
 import static org.apache.bookkeeper.mledger.proto.MLDataFormats.ManagedLedgerInfo.LedgerInfo;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
+import javax.ws.rs.NotAllowedException;
+import javax.ws.rs.NotFoundException;
 import lombok.Cleanup;
 import org.apache.bookkeeper.mledger.ManagedCursor;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.admin.PulsarAdminException;
 import org.apache.pulsar.client.api.Consumer;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.PulsarClientException;
 import org.apache.pulsar.client.api.Schema;
 import org.apache.pulsar.client.api.SubscriptionType;
 import org.apache.pulsar.client.impl.MessageIdImpl;
 import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
 import org.apache.pulsar.common.util.FutureUtil;
+import org.assertj.core.api.ThrowableAssert;
 import org.assertj.core.util.Sets;
 import org.awaitility.Awaitility;
 import org.testng.Assert;
@@ -420,4 +426,93 @@ public class BrokerEntryMetadataE2ETest extends BrokerTestBase {
 
         cursor.close();
     }
+
+    @Test
+    public void testGetMessageIdByIndex() throws Exception {
+        // 1. test no partitioned topic
+        final String topicName = newTopicName();
+        admin.topics().createNonPartitionedTopic(topicName);
+        @Cleanup
+        Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topicName)
+                .enableBatching(false)
+                .create();
+        MessageIdImpl messageId = (MessageIdImpl) producer.send("test");
+        Message<byte[]>
+                message =
+                admin.topics().getMessagesById(topicName, messageId.getLedgerId(), messageId.getEntryId()).get(0);
+        long index = message.getIndex().get();
+        MessageIdImpl messageIdByIndex = (MessageIdImpl) admin.topics().getMessageIdByIndex(topicName, index);
+        Assert.assertEquals(messageIdByIndex, messageId);
+
+        // 2. test partitioned topic
+        final String topicName2 = newTopicName();
+        final String partitionedTopicName = topicName2 + "-partition-" + 0;
+        admin.topics().createPartitionedTopic(topicName2, 10);
+        @Cleanup
+        Producer<String> producer2 = pulsarClient.newProducer(Schema.STRING)
+                .topic(topicName2)
+                .enableBatching(false)
+                .create();
+
+        MessageIdImpl messageId2 = null;
+        for (int i = 0; i < 200; i++) {
+            messageId2 = (MessageIdImpl) producer2.send("test" + i);
+            if (messageId2.getPartitionIndex() == 0) {
+                break;
+            }
+        }
+        Message<byte[]>
+                message2 = admin.topics().getMessagesById(partitionedTopicName,
+                messageId2.getLedgerId(), messageId2.getEntryId()).get(0);
+        long index2 = message2.getIndex().get();
+        // 2.1 test partitioned topic name with partition index
+        MessageIdImpl messageIdByIndex2 =
+                (MessageIdImpl) admin.topics().getMessageIdByIndex(partitionedTopicName, index2);
+        Assert.assertEquals(messageIdByIndex2, messageId2);
+        // 2.2 test partitioned topic name without partition index
+        assertThrowsWithCause(() -> admin.topics().getMessageIdByIndex(topicName2, index2),
+                PulsarAdminException.class, NotAllowedException.class);
+
+        // 3. test invalid index
+        assertThrowsWithCause(() -> admin.topics().getMessageIdByIndex(topicName, -1),
+                PulsarAdminException.class, NotFoundException.class);
+
+        assertThrowsWithCause(() -> admin.topics().getMessageIdByIndex(topicName, 100000),
+                PulsarAdminException.class, NotFoundException.class);
+    }
+
+    @Test
+    public void testGetMessageIdByIndexForEmptyTopic() throws PulsarAdminException {
+        final String topicName = newTopicName();
+        admin.topics().createNonPartitionedTopic(topicName);
+
+        assertThrowsWithCause(() -> admin.topics().getMessageIdByIndex(topicName, 0),
+                PulsarAdminException.class, NotFoundException.class);
+    }
+
+    @Test
+    public void testGetMessageIdByIndexOutOfIndex() throws PulsarAdminException, PulsarClientException {
+        final String topicName = newTopicName();
+        admin.topics().createNonPartitionedTopic(topicName);
+        @Cleanup
+        final Producer<String> producer = pulsarClient.newProducer(Schema.STRING)
+                .topic(topicName)
+                .create();
+        for (int i = 0; i < 100; i++) {
+            producer.send("msg-" + i);
+        }
+
+        assertThrowsWithCause(() -> admin.topics().getMessageIdByIndex(topicName, 1000),
+                PulsarAdminException.class, NotFoundException.class);
+    }
+
+    private void assertThrowsWithCause(ThrowableAssert.ThrowingCallable executable,
+                                       Class<? extends Throwable> expectedException,
+                                       Class<? extends Throwable> expectedCause) {
+        assertThatThrownBy(executable)
+                .isInstanceOf(expectedException)
+                .hasRootCauseInstanceOf(expectedCause);
+    }
+
 }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentDispatcherFailoverConsumerTest.java
@@ -163,7 +163,8 @@ public class PersistentDispatcherFailoverConsumerTest {
         NamespaceService nsSvc = pulsarTestContext.getPulsarService().getNamespaceService();
         doReturn(true).when(nsSvc).isServiceUnitOwned(any(NamespaceBundle.class));
         doReturn(true).when(nsSvc).isServiceUnitActive(any(TopicName.class));
-        doReturn(CompletableFuture.completedFuture(true)).when(nsSvc).checkTopicOwnership(any(TopicName.class));
+        doReturn(CompletableFuture.completedFuture(mock(NamespaceBundle.class))).when(nsSvc).getBundleAsync(any());
+        doReturn(CompletableFuture.completedFuture(true)).when(nsSvc).checkBundleOwnership(any(), any());
 
         setupMLAsyncCallbackMocks();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentMessageFinderTest.java
@@ -47,6 +47,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.MediaType;
+import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.AsyncCallbacks;
 import org.apache.bookkeeper.mledger.Entry;
 import org.apache.bookkeeper.mledger.ManagedCursor;
@@ -67,6 +68,9 @@ import org.apache.pulsar.broker.service.persistent.PersistentMessageExpiryMonito
 import org.apache.pulsar.broker.service.persistent.PersistentMessageFinder;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.impl.MessageIdImpl;
+import org.apache.pulsar.client.impl.MessageImpl;
 import org.apache.pulsar.client.impl.ResetCursorData;
 import org.apache.pulsar.common.allocator.PulsarByteBufAllocator;
 import org.apache.pulsar.common.api.proto.BrokerEntryMetadata;
@@ -81,6 +85,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 @Test(groups = "broker")
+@Slf4j
 public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
 
     public static byte[] createMessageWrittenToLedger(String msg) {
@@ -144,7 +149,12 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
     }
 
     CompletableFuture<Void> findMessage(final Result result, final ManagedCursor c1, final long timestamp) {
-        PersistentMessageFinder messageFinder = new PersistentMessageFinder("topicname", c1, 0);
+        return findMessage(result, c1, timestamp, 0);
+    }
+
+    CompletableFuture<Void> findMessage(final Result result, final ManagedCursor c1, final long timestamp,
+                                        int ledgerCloseTimestampMaxClockSkewMillis) {
+        PersistentMessageFinder messageFinder = new PersistentMessageFinder("topicname", c1, ledgerCloseTimestampMaxClockSkewMillis);
 
         final CompletableFuture<Void> future = new CompletableFuture<>();
         messageFinder.findMessages(timestamp, new AsyncCallbacks.FindEntryCallback() {
@@ -437,6 +447,153 @@ public class PersistentMessageFinderTest extends MockedBookKeeperTestCase {
         ledger.close();
         factory.shutdown();
 
+    }
+
+    public void testFindMessageWithTimestampAutoSkipNonRecoverable() throws Exception {
+
+        final String ledgerAndCursorName = "testFindMessageWithTimestampAutoSkipNonRecoverable";
+        final int entriesPerLedger = 5;
+        final int totalEntries = 50;
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setRetentionSizeInMB(10);
+        config.setMaxEntriesPerLedger(entriesPerLedger);
+        config.setRetentionTime(1, TimeUnit.HOURS);
+        config.setAutoSkipNonRecoverableData(true);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open(ledgerAndCursorName, config);
+
+        long initTimeMillis = System.currentTimeMillis();
+        for (int i = 0; i < totalEntries; i++) {
+            ledger.addEntry(createMessageWrittenToLedger("msg" + i, initTimeMillis + i));
+        }
+        // {0,1,2,3,4} (0) 3 x
+        // {5,6,7,8,9} (1) 4
+        // {10,11,12,13,14} (2) 5
+        // {15,16,17,18,19} (3) 6
+        // {20,21,22,23,24} (4) 7 x
+        // {25,26,27,28,29} (5) 8 x
+        // {30,31,32,33,34} (6) 9
+        // {35,36,37,38,39} (7) 10
+        // {40,41,42,43,44} (8) 11
+        // {45,46,47,48,49} (9) 12 x
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(ledger.getState(), ManagedLedgerImpl.State.LedgerOpened));
+
+        List<LedgerInfo> ledgers = ledger.getLedgersInfoAsList();
+        LedgerInfo lastLedgerInfo = ledgers.get(ledgers.size() - 1);
+        // The `lastLedgerInfo` should be newly opened, and it does not contain any entries.
+        // Please refer to: https://github.com/apache/pulsar/pull/22034
+        assertEquals(lastLedgerInfo.getEntries(), 0);
+        assertEquals(ledgers.size(), totalEntries / entriesPerLedger + 1);
+
+        bkc.deleteLedger(ledgers.get(0).getLedgerId());
+        bkc.deleteLedger(ledgers.get(4).getLedgerId());
+        bkc.deleteLedger(ledgers.get(5).getLedgerId());
+        bkc.deleteLedger(ledgers.get(9).getLedgerId());
+
+        MessageId messageId = findMessageIdByPublishTime(initTimeMillis + 17, ledger).join();
+        log.info("messageId: {}", messageId);
+        assertEquals(messageId, new MessageIdImpl(ledgers.get(3).getLedgerId(), 2, -1));
+
+        messageId = findMessageIdByPublishTime(initTimeMillis + 27, ledger).join();
+        log.info("messageId: {}", messageId);
+        assertEquals(messageId, new MessageIdImpl(ledgers.get(4).getLedgerId(), 0, -1));
+
+        messageId = findMessageIdByPublishTime(initTimeMillis + 43, ledger).join();
+        log.info("messageId: {}", messageId);
+        assertEquals(messageId, new MessageIdImpl(ledgers.get(8).getLedgerId(), 3, -1));
+
+        messageId = findMessageIdByPublishTime(initTimeMillis + 48, ledger).join();
+        log.info("messageId: {}", messageId);
+        assertEquals(messageId, new MessageIdImpl(ledgers.get(9).getLedgerId(), 0, -1));
+
+        ledger.close();
+        factory.shutdown();
+    }
+
+    public void testFindMessageByCursorWithTimestampAutoSkipNonRecoverable() throws Exception {
+
+        final String ledgerAndCursorName = "testFindMessageByCursorWithTimestampAutoSkipNonRecoverable";
+        final int entriesPerLedger = 5;
+        final int totalEntries = 50;
+
+        ManagedLedgerConfig config = new ManagedLedgerConfig();
+        config.setRetentionSizeInMB(10);
+        config.setMaxEntriesPerLedger(entriesPerLedger);
+        config.setRetentionTime(1, TimeUnit.HOURS);
+        config.setAutoSkipNonRecoverableData(true);
+        ManagedLedgerImpl ledger = (ManagedLedgerImpl) factory.open(ledgerAndCursorName, config);
+        ManagedCursorImpl cursor = (ManagedCursorImpl) ledger.openCursor(ledgerAndCursorName);
+
+        long initTimeMillis = System.currentTimeMillis();
+        for (int i = 0; i < totalEntries; i++) {
+            ledger.addEntry(createMessageWrittenToLedger("msg" + i, initTimeMillis + i));
+        }
+        // {0,1,2,3,4} (0) 3 x
+        // {5,6,7,8,9} (1) 4
+        // {10,11,12,13,14} (2) 5
+        // {15,16,17,18,19} (3) 6
+        // {20,21,22,23,24} (4) 7 x
+        // {25,26,27,28,29} (5) 8 x
+        // {30,31,32,33,34} (6) 9
+        // {35,36,37,38,39} (7) 10
+        // {40,41,42,43,44} (8) 11
+        // {45,46,47,48,49} (9) 12 x
+        Awaitility.await().untilAsserted(() ->
+                assertEquals(ledger.getState(), ManagedLedgerImpl.State.LedgerOpened));
+
+        List<LedgerInfo> ledgers = ledger.getLedgersInfoAsList();
+        LedgerInfo lastLedgerInfo = ledgers.get(ledgers.size() - 1);
+        // The `lastLedgerInfo` should be newly opened, and it does not contain any entries.
+        // Please refer to: https://github.com/apache/pulsar/pull/22034
+        assertEquals(lastLedgerInfo.getEntries(), 0);
+        assertEquals(ledgers.size(), totalEntries / entriesPerLedger + 1);
+
+        bkc.deleteLedger(ledgers.get(0).getLedgerId());
+        bkc.deleteLedger(ledgers.get(4).getLedgerId());
+        bkc.deleteLedger(ledgers.get(5).getLedgerId());
+        bkc.deleteLedger(ledgers.get(9).getLedgerId());
+        Result result = new Result();
+
+        findMessage(result, cursor, initTimeMillis + 17, -1).join();
+        log.info("position: {}", result.position);
+        assertNull(result.exception);
+        assertEquals(result.position, PositionFactory.create(ledgers.get(3).getLedgerId(), 1));
+
+        result = new Result();
+        findMessage(result, cursor, initTimeMillis + 27, -1).join();
+        log.info("position: {}", result.position);
+        assertNull(result.exception);
+        assertEquals(result.position, PositionFactory.create(ledgers.get(3).getLedgerId(), 4));
+
+        result = new Result();
+        findMessage(result, cursor, initTimeMillis + 43, -1).join();
+        log.info("position: {}", result.position);
+        assertNull(result.exception);
+        assertEquals(result.position, PositionFactory.create(ledgers.get(8).getLedgerId(), 2));
+
+        ledger.close();
+        factory.shutdown();
+    }
+
+    private CompletableFuture<MessageId> findMessageIdByPublishTime(long timestamp, ManagedLedger managedLedger) {
+        return managedLedger.asyncFindPosition(entry -> {
+            try {
+                long entryTimestamp = Commands.getEntryTimestamp(entry.getDataBuffer());
+                return MessageImpl.isEntryPublishedEarlierThan(entryTimestamp, timestamp);
+            } catch (Exception e) {
+                log.error("Error deserializing message for message position find", e);
+            } finally {
+                entry.release();
+            }
+            return false;
+        }).thenApply(position -> {
+            if (position == null) {
+                return null;
+            } else {
+                return new MessageIdImpl(position.getLedgerId(), position.getEntryId(), -1);
+            }
+        });
     }
 
     @Test

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicConcurrentTest.java
@@ -104,7 +104,8 @@ public class PersistentTopicConcurrentTest extends MockedBookKeeperTestCase {
         doReturn(nsSvc).when(pulsar).getNamespaceService();
         doReturn(true).when(nsSvc).isServiceUnitOwned(any(NamespaceBundle.class));
         doReturn(true).when(nsSvc).isServiceUnitActive(any(TopicName.class));
-        doReturn(CompletableFuture.completedFuture(true)).when(nsSvc).checkTopicOwnership(any(TopicName.class));
+        doReturn(CompletableFuture.completedFuture(mock(NamespaceBundle.class))).when(nsSvc).getBundleAsync(any());
+        doReturn(CompletableFuture.completedFuture(true)).when(nsSvc).checkBundleOwnership(any(), any());
 
         final List<Position> addedEntries = new ArrayList<>();
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/PersistentTopicTest.java
@@ -226,7 +226,8 @@ public class PersistentTopicTest extends MockedBookKeeperTestCase {
         doReturn(true).when(nsSvc).isServiceUnitOwned(any());
         doReturn(true).when(nsSvc).isServiceUnitActive(any());
         doReturn(CompletableFuture.completedFuture(true)).when(nsSvc).isServiceUnitActiveAsync(any());
-        doReturn(CompletableFuture.completedFuture(true)).when(nsSvc).checkTopicOwnership(any());
+        doReturn(CompletableFuture.completedFuture(mock(NamespaceBundle.class))).when(nsSvc).getBundleAsync(any());
+        doReturn(CompletableFuture.completedFuture(true)).when(nsSvc).checkBundleOwnership(any(), any());
 
         setupMLAsyncCallbackMocks();
     }

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/ServerCnxTest.java
@@ -144,6 +144,7 @@ import org.apache.pulsar.common.api.proto.ProtocolVersion;
 import org.apache.pulsar.common.api.proto.ServerError;
 import org.apache.pulsar.common.api.proto.Subscription;
 import org.apache.pulsar.common.api.proto.TxnAction;
+import org.apache.pulsar.common.naming.NamespaceBundle;
 import org.apache.pulsar.common.naming.NamespaceName;
 import org.apache.pulsar.common.naming.TopicName;
 import org.apache.pulsar.common.policies.data.AuthAction;
@@ -226,11 +227,12 @@ public class ServerCnxTest {
         brokerService = pulsarTestContext.getBrokerService();
 
         namespaceService = pulsar.getNamespaceService();
-        doReturn(CompletableFuture.completedFuture(null)).when(namespaceService).getBundleAsync(any());
+        doReturn(CompletableFuture.completedFuture(mock(NamespaceBundle.class))).when(namespaceService)
+                .getBundleAsync(any());
+        doReturn(CompletableFuture.completedFuture(true)).when(namespaceService).checkBundleOwnership(any(), any());
         doReturn(true).when(namespaceService).isServiceUnitOwned(any());
         doReturn(true).when(namespaceService).isServiceUnitActive(any());
         doReturn(CompletableFuture.completedFuture(true)).when(namespaceService).isServiceUnitActiveAsync(any());
-        doReturn(CompletableFuture.completedFuture(true)).when(namespaceService).checkTopicOwnership(any());
         doReturn(CompletableFuture.completedFuture(topics)).when(namespaceService).getListOfTopics(
                 NamespaceName.get("use", "ns-abc"), CommandGetTopicsOfNamespace.Mode.ALL);
         doReturn(CompletableFuture.completedFuture(topics)).when(namespaceService).getListOfUserTopics(

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/service/SubscriptionSeekTest.java
@@ -30,6 +30,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -46,6 +47,7 @@ import org.apache.bookkeeper.mledger.ManagedLedger;
 import org.apache.bookkeeper.mledger.ManagedLedgerConfig;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.proto.MLDataFormats;
+import org.apache.commons.lang3.ArraySorter;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pulsar.broker.service.persistent.PersistentSubscription;
 import org.apache.pulsar.broker.service.persistent.PersistentTopic;
@@ -88,6 +90,7 @@ public class SubscriptionSeekTest extends BrokerTestBase {
         conf.setManagedLedgerMaxEntriesPerLedger(10);
         conf.setDefaultRetentionSizeInMB(100);
         conf.setDefaultRetentionTimeInMinutes(100);
+        conf.setAutoSkipNonRecoverableData(true);
         super.baseSetup();
     }
 
@@ -560,6 +563,89 @@ public class SubscriptionSeekTest extends BrokerTestBase {
             Position readPosition = cursor.getReadPosition();
             Assert.assertEquals(readPosition.getLedgerId(), messageId.getLedgerId());
             Assert.assertEquals(readPosition.getEntryId(), messageId.getEntryId());
+        }
+    }
+
+    @Test(timeOut = 30_000)
+    public void testSeekByTimestampWithSkipNonRecoverableData() throws Exception {
+        String topicName = "persistent://prop/use/ns-abc/testSeekByTimestampWithSkipNonRecoverableData";
+        admin.topics().createNonPartitionedTopic(topicName);
+        admin.topics().createSubscription(topicName, "my-sub", MessageId.earliest);
+
+        @Cleanup
+        Producer<String> producer =
+            pulsarClient.newProducer(Schema.STRING).topic(topicName).enableBatching(false).create();
+        for (int i = 0; i < 55; i++) {
+            producer.send(("message-" + i));
+            Thread.sleep(10);
+        }
+
+        Map<Long, MessageIdImpl> timestampToMessageId = new HashMap<>();
+        List<Long> ledgerIds = new ArrayList<>();
+        @Cleanup
+        Reader<String> reader =
+            pulsarClient.newReader(Schema.STRING).topic(topicName).startMessageId(MessageId.earliest).create();
+        while (reader.hasMessageAvailable()) {
+            Message<String> message = reader.readNext();
+            log.info("message: {} ----- {}", message.getMessageId(), message.getPublishTime());
+            timestampToMessageId.put(message.getPublishTime(), (MessageIdImpl) message.getMessageId());
+            long ledgerId = ((MessageIdImpl) message.getMessageId()).getLedgerId();
+            if (!ledgerIds.contains(ledgerId)) {
+                ledgerIds.add(ledgerId);
+            }
+        }
+
+        Assert.assertEquals(timestampToMessageId.size(), 55);
+
+        LinkedHashSet<Long> deletedLedgerIds = new LinkedHashSet<>();
+        deletedLedgerIds.add(ledgerIds.get(0));
+        deletedLedgerIds.add(ledgerIds.get(ledgerIds.size() - 1));
+        int mid = ledgerIds.size() / 2;
+        deletedLedgerIds.add(ledgerIds.get(mid));
+
+        for (Long deletedLedgerId : deletedLedgerIds) {
+            pulsar.getBookKeeperClient().deleteLedger(deletedLedgerId);
+            log.info("delete ledger: {}", deletedLedgerId);
+        }
+
+        admin.topics().unload(topicName);
+
+        @Cleanup
+        org.apache.pulsar.client.api.Consumer<String> consumer = pulsarClient.newConsumer(Schema.STRING)
+            .receiverQueueSize(0)
+            .topic(topicName).subscriptionName("my-sub")
+            .subscriptionInitialPosition(SubscriptionInitialPosition.Earliest).subscribe();
+        long[] timestamps = timestampToMessageId.keySet().stream().mapToLong(Long::longValue).toArray();
+        ArraySorter.sort(timestamps);
+
+        timestampToMessageId.values().removeIf(messageId -> deletedLedgerIds.contains(messageId.getLedgerId()));
+
+        final int lastNonRecoverableEntryNums = 5;
+
+        for (int i = 0; i < timestamps.length - lastNonRecoverableEntryNums; i++) {
+            MessageIdImpl nextValidMessageId = timestampToMessageId.get(timestamps[i]);
+            int l = i;
+            while (nextValidMessageId == null) {
+                nextValidMessageId = timestampToMessageId.get(timestamps[l++]);
+            }
+
+            consumer.seek(timestamps[i]);
+            Message<String> receive = consumer.receive();
+
+            MessageIdImpl msgId = (MessageIdImpl) receive.getMessageId();
+            Assert.assertEquals(msgId.getLedgerId(), nextValidMessageId.getLedgerId());
+            Assert.assertEquals(msgId.getEntryId(), nextValidMessageId.getEntryId());
+        }
+
+        MessageIdImpl lastMessageId = (MessageIdImpl) producer.send(("message-last"));
+
+        for (int i = timestamps.length - lastNonRecoverableEntryNums; i < timestamps.length; i++) {
+            consumer.seek(timestamps[i]);
+            Message<String> receive = consumer.receive();
+
+            MessageIdImpl msgId = (MessageIdImpl) receive.getMessageId();
+            Assert.assertEquals(msgId.getLedgerId(), lastMessageId.getLedgerId());
+            Assert.assertEquals(msgId.getEntryId(), lastMessageId.getEntryId());
         }
     }
 

--- a/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/broker/stats/ConsumerStatsTest.java
@@ -268,6 +268,8 @@ public class ConsumerStatsTest extends ProducerConsumerBase {
                 "lastAckedTimestamp",
                 "lastConsumedTime",
                 "lastConsumedTimestamp",
+                "firstMessagesSentTimestamp",
+                "firstConsumedFlowTimestamp",
                 "lastConsumedFlowTimestamp",
                 "metadata",
                 "address",

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndTest.java
@@ -46,6 +46,7 @@ import lombok.Cleanup;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.bookkeeper.mledger.Position;
 import org.apache.bookkeeper.mledger.impl.ManagedLedgerImpl;
+import org.apache.pulsar.broker.BrokerTestUtil;
 import org.apache.pulsar.broker.TransactionMetadataStoreService;
 import org.apache.pulsar.broker.service.BrokerService;
 import org.apache.pulsar.broker.service.Topic;
@@ -449,8 +450,76 @@ public class TransactionEndToEndTest extends TransactionTestBase {
         log.info("finished test partitionAbortTest");
     }
 
+    @DataProvider
+    public Object[][] unackMessagesCountParams() {
+        return new Object[][] {
+                // batchSend, batchAck, asyncAck
+                {Boolean.TRUE, Boolean.TRUE, Boolean.TRUE},
+                {Boolean.TRUE, Boolean.TRUE, Boolean.FALSE},
+                {Boolean.TRUE, Boolean.FALSE, Boolean.TRUE},
+                {Boolean.TRUE, Boolean.FALSE, Boolean.FALSE},
+                {Boolean.FALSE, Boolean.TRUE, Boolean.TRUE},
+                {Boolean.FALSE, Boolean.TRUE, Boolean.FALSE},
+                {Boolean.FALSE, Boolean.FALSE, Boolean.TRUE},
+                {Boolean.FALSE, Boolean.FALSE, Boolean.FALSE}
+        };
+    }
+
+    @Test(dataProvider= "unackMessagesCountParams")
+    public void testUnackMessageAfterAckAllMessages(boolean batchSend, boolean batchAck, boolean asyncAck)
+            throws Exception {
+        final int messageCount = 50;
+        final String subName = "s1";
+        final String topicName = BrokerTestUtil.newUniqueName(NAMESPACE1 + "/tp");
+        // Create producer and consumer.
+        Consumer<byte[]> consumer = pulsarClient.newConsumer().topic(topicName).subscriptionName(subName)
+                .subscriptionType(SubscriptionType.Shared).isAckReceiptEnabled(true).subscribe();
+        Awaitility.await().until(consumer::isConnected);
+        Producer<byte[]> producer = pulsarClient.newProducer().topic(topicName).enableBatching(batchSend)
+                .batchingMaxMessages(10).create();
+        Awaitility.await().until(producer::isConnected);
+        // Publish messages.
+        CompletableFuture<MessageId> latestSendFuture = null;
+        for (int i = 0; i < messageCount; i++) {
+            latestSendFuture = producer.sendAsync((i + "").getBytes());
+        }
+        latestSendFuture.join();
+
+        // Ack messages with TXN.
+        Transaction txn = getTxn();
+        List<MessageId> msgIds = new ArrayList<>();
+        for (int i = 0; i < messageCount; i++) {
+            Message<byte[]> message = consumer.receive(waitTimeForCanReceiveMsgInSec, TimeUnit.SECONDS);
+            msgIds.add(message.getMessageId());
+        }
+        if (batchAck) {
+            consumer.acknowledgeAsync(msgIds, txn).get();
+        } else if (asyncAck) {
+            CompletableFuture<Void> latestAckFuture = null;
+            for (MessageId msgId : msgIds) {
+                latestAckFuture = consumer.acknowledgeAsync(msgId, txn);
+            }
+            latestAckFuture.join();
+        } else {
+            for (MessageId msgId : msgIds) {
+                consumer.acknowledgeAsync(msgId, txn).get();
+            }
+        }
+        txn.commit().get();
+
+        // Verify: the quantity of un-ack messages is 0.
+        int unAckMsgs = admin.topics().getStats(topicName).getSubscriptions().get(subName).getConsumers().get(0)
+                .getUnackedMessages();
+        assertEquals(unAckMsgs, 0);
+
+        // cleanup.
+        producer.close();
+        consumer.close();
+        admin.topics().delete(topicName, true);
+    }
+
     @Test(dataProvider="enableBatch")
-    private void testAckWithTransactionReduceUnAckMessageCount(boolean enableBatch) throws Exception {
+    public void testAckWithTransactionReduceUnAckMessageCount(boolean enableBatch) throws Exception {
 
         final int messageCount = 50;
         final String subName = "testAckWithTransactionReduceUnAckMessageCount";

--- a/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndWithoutBatchIndexAckTest.java
+++ b/pulsar-broker/src/test/java/org/apache/pulsar/client/impl/TransactionEndToEndWithoutBatchIndexAckTest.java
@@ -43,4 +43,17 @@ public class TransactionEndToEndWithoutBatchIndexAckTest extends TransactionEndT
         conf.setAcknowledgmentAtBatchIndexLevelEnabled(true);
         txnAckTest(true, 200, SubscriptionType.Failover);
     }
+
+    @Override
+    @Test(dataProvider="unackMessagesCountParams", enabled = false)
+    public void testUnackMessageAfterAckAllMessages(boolean batchSend, boolean batchAck, boolean asyncAck)
+            throws Exception {
+        super.testUnackMessageAfterAckAllMessages(batchSend, batchAck, asyncAck);
+    }
+
+    @Override
+    @Test(dataProvider="enableBatch", enabled = false)
+    public void testAckWithTransactionReduceUnAckMessageCount(boolean enableBatch) throws Exception {
+        super.testAckWithTransactionReduceUnAckMessageCount(enableBatch);
+    }
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/client/admin/Topics.java
@@ -4558,4 +4558,61 @@ public interface Topics {
     default CompletableFuture<Void> createShadowTopicAsync(String shadowTopic, String sourceTopic) {
         return createShadowTopicAsync(shadowTopic, sourceTopic, null);
     }
+
+    /**
+     * Get the message id by index. If the index points to a system message, return the first user message following it;
+     * if the specified message has expired and been deleted, return MessageId.Earliest.
+     * The messages without entry metadata will be skipped, and the next matched message whose index >= the specified
+     * index will be returned.
+     * @param topicName either the specific partition name of a partitioned topic (e.g. my-topic-partition-0)
+     *                 or the original topic name for non-partitioned topics.
+     * @param index the index of a message
+     * @return the message id of the message.
+     * When retrieving a message ID by index, the resolution is limited to the **entry** level (an entry is the minimal
+     * storage unit for messages in Pulsar's persistence layer).
+     * If message batching is enabled, a single entry may contain multiple messages with distinct indexes.
+     * Example Scenario (partition with 2 entries):
+     * | Entry | Ledger ID | Entry ID | Index | Messages |
+     * | :--- | ---: | ---: | ---: | ---: |
+     * | A | 0 | 0 | 2 | 0,1,2 |
+     * | B | 0 | 1 | 4 | 3,4 |
+     * Param with indexes 0,1,2 or 3,4 will return the **same MessageID** (e.g., `MessageId(0:0:*)` for Entry A).
+     * @throws NotAuthorizedException      (HTTP 403 Forbidden) Client lacks permissions to access the topic/namespace.
+     * @throws NotFoundException           (HTTP 404 Not Found) Source topic/namespace does not exist, or invalid index.
+     * @throws PulsarAdminException        (HTTP 406 Not Acceptable) Specified topic is not a persistent topic.
+     * @throws PreconditionFailedException (HTTP 412 Precondition Failed) Broker entry metadata is disabled.
+     * @throws PulsarAdminException        For other errors (e.g., HTTP 500 Internal Server Error).
+     */
+    MessageId getMessageIdByIndex(String topicName, long index) throws PulsarAdminException;
+
+
+    /**
+     * Get the message id by index asynchronously. If the index points to a system message, return the first user
+     * message following it; if the specified message has expired and been deleted, return MessageId.Earliest.
+     * The messages without entry metadata will be skipped, and the next matched message whose index >= the specified
+     * index will be returned.
+     * @param topicName either the specific partition name of a partitioned topic (e.g. my-topic-partition-0) or
+     *                 the original topic name for non-partitioned topics.
+     * @param index the index of a message
+     * When retrieving a message ID by index, the resolution is limited to the **entry** level (an entry is the minimal
+     *              storage unit for messages in Pulsar's persistence layer).
+     * If message batching is enabled, a single entry may contain multiple messages with distinct indexes.
+     * Example Scenario (partition with 2 entries):
+     * | Entry | Ledger ID | Entry ID | Index | Messages |
+     * | :--- | ---: | ---: | ---: | ---: |
+     * | A | 0 | 0 | 2 | 0,1,2 |
+     * | B | 0 | 1 | 4 | 3,4 |
+     * Param with indexes 0,1,2 or 3,4 will return the **same MessageID** (e.g., `MessageId(0:0:*)` for Entry A).
+     * @implNote The return {@link CompletableFuture<MessageId>} that completes with the message id of the message.
+     *         The future may complete exceptionally with:
+     *         <ul>
+     *             <li>{@link NotAuthorizedException} (HTTP 403) Permission denied for topic/namespace access.</li>
+     *             <li>{@link NotFoundException} (HTTP 404) Shadow topic/namespace does not exist or invalid index.</li>
+     *             <li>{@link PulsarAdminException} (HTTP 406) Shadow topic is not a persistent topic.</li>
+     *             <li>{@link PreconditionFailedException} (HTTP 412) Broker entry metadata is not enabled.</li>
+     *             <li>{@link PulsarAdminException} (HTTP 307) Redirect required to the correct broker.</li>
+     *             <li>{@link PulsarAdminException} Other errors (e.g., HTTP 500).</li>
+     *         </ul>
+     */
+    CompletableFuture<MessageId> getMessageIdByIndexAsync(String topicName, long index);
 }

--- a/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
+++ b/pulsar-client-admin-api/src/main/java/org/apache/pulsar/common/policies/data/ConsumerStats.java
@@ -120,6 +120,8 @@ public interface ConsumerStats {
     long getLastAckedTimestamp();
     long getLastConsumedTimestamp();
     long getLastConsumedFlowTimestamp();
+    long getFirstMessagesSentTimestamp();
+    long getFirstConsumedFlowTimestamp();
 
     /**
      * Hash ranges assigned to this consumer if in Key_Shared subscription mode.

--- a/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
+++ b/pulsar-client-admin/src/main/java/org/apache/pulsar/client/admin/internal/TopicsImpl.java
@@ -2819,5 +2819,31 @@ public class TopicsImpl extends BaseResource implements Topics {
         });
     }
 
+    @Override
+    public MessageId getMessageIdByIndex(String topicName, long index) throws PulsarAdminException {
+        return sync(() -> getMessageIdByIndexAsync(topicName, index));
+    }
+
+    @Override
+    public CompletableFuture<MessageId> getMessageIdByIndexAsync(String topicName, long index) {
+        final CompletableFuture<MessageId> messageIdCompletableFuture = new CompletableFuture<>();
+        TopicName topic = validateTopic(topicName);
+        WebTarget path = topicPath(topic, "getMessageIdByIndex");
+        path = path.queryParam("index", index);
+        asyncGetRequest(path, new InvocationCallback<MessageIdImpl>(){
+
+            @Override
+            public void completed(MessageIdImpl messageId) {
+                messageIdCompletableFuture.complete(messageId);
+            }
+
+            @Override
+            public void failed(Throwable throwable) {
+                messageIdCompletableFuture.completeExceptionally(throwable);
+            }
+        });
+        return messageIdCompletableFuture;
+    }
+
     private static final Logger log = LoggerFactory.getLogger(TopicsImpl.class);
 }

--- a/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
+++ b/pulsar-client-tools-test/src/test/java/org/apache/pulsar/admin/cli/PulsarAdminToolTest.java
@@ -2090,7 +2090,8 @@ public class PulsarAdminToolTest {
         cmdTopics.run(split("get-shadow-source persistent://myprop/clust/ns1/ds1"));
         verify(mockTopics).getShadowSource("persistent://myprop/clust/ns1/ds1");
 
-
+        cmdTopics.run(split("get-message-id-by-index persistent://myprop/clust/ns1/ds1 -i 0"));
+        verify(mockTopics).getMessageIdByIndex("persistent://myprop/clust/ns1/ds1", 0);
 
     }
 

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -275,6 +275,8 @@ public class CmdTopics extends CmdBase {
         addCommand("set-schema-validation-enforce", new SetSchemaValidationEnforced());
 
         addCommand("trim-topic", new TrimTopic());
+
+        addCommand("get-message-id-by-index", new GetMessageIdByIndex());
     }
 
     @Command(description = "Get the list of topics under a namespace.")
@@ -3056,6 +3058,22 @@ public class CmdTopics extends CmdBase {
         void run() throws PulsarAdminException {
             String topic = validateTopicName(topicName);
             getAdmin().topics().trimTopic(topic);
+        }
+    }
+
+    @Command(description = "Get message id by index")
+    private class GetMessageIdByIndex extends CliCommand {
+
+        @Parameters(description = "persistent://tenant/namespace/topic", arity = "1")
+        private String topicName;
+
+        @Option(names = { "--index", "-i" }, description = "Index to get message id for the topic", required = true)
+        private Long index;
+
+        @Override
+        void run() throws Exception {
+            String topic = validateTopicName(topicName);
+            getAdmin().topics().getMessageIdByIndex(topic, index);
         }
     }
 }

--- a/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
+++ b/pulsar-client-tools/src/main/java/org/apache/pulsar/admin/cli/CmdTopics.java
@@ -3073,7 +3073,7 @@ public class CmdTopics extends CmdBase {
         @Override
         void run() throws Exception {
             String topic = validateTopicName(topicName);
-            getAdmin().topics().getMessageIdByIndex(topic, index);
+            System.out.println(getAdmin().topics().getMessageIdByIndex(topic, index));
         }
     }
 }

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ClientCnx.java
@@ -644,10 +644,12 @@ public class ClientCnx extends PulsarHandler {
             if (!lookupResult.hasResponse()
                     || CommandLookupTopicResponse.LookupType.Failed.equals(lookupResult.getResponse())) {
                 if (lookupResult.hasError()) {
-                    checkServerError(lookupResult.getError(), lookupResult.getMessage());
+                    checkServerError(lookupResult.getError(),
+                            lookupResult.hasMessage() ? lookupResult.getMessage() : lookupResult.getError().name());
                     requestFuture.completeExceptionally(
                             getPulsarClientException(lookupResult.getError(),
-                                    buildError(lookupResult.getRequestId(), lookupResult.getMessage())));
+                                    buildError(lookupResult.getRequestId(),
+                                            lookupResult.hasMessage() ? lookupResult.getMessage() : null)));
                 } else {
                     requestFuture
                             .completeExceptionally(new PulsarClientException.LookupException("Empty lookup response"));

--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/ConsumerImpl.java
@@ -3251,6 +3251,7 @@ public class ConsumerImpl<T> extends ConsumerBase<T> implements ConnectionHandle
             if (MessageIdAdvUtils.isBatch(messageIdAdv)) {
                 final BitSetRecyclable bitSetRecyclable = BitSetRecyclable.create();
                 bitSetRecyclable.set(0, messageIdAdv.getBatchSize());
+                messageIdData.setBatchSize(messageIdAdv.getBatchSize());
                 if (ackType == AckType.Cumulative) {
                     MessageIdAdvUtils.acknowledge(messageIdAdv, false);
                     bitSetRecyclable.clear(0, messageIdAdv.getBatchIndex() + 1);

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/ConsumerStatsImpl.java
@@ -119,7 +119,12 @@ public class ConsumerStatsImpl implements ConsumerStats {
     @Deprecated
     public long lastConsumedTimestamp;
 
+    // The first timestamp of successfully sending a message to the consumer
+    public long firstMessagesSentTimestamp;
     public long lastConsumedFlowTimestamp;
+    // The first timestamp of consumer flow request
+    public long firstConsumedFlowTimestamp;
+
 
     /**
      * Hash ranges assigned to this consumer if in Key_Shared subscription mode.
@@ -156,6 +161,8 @@ public class ConsumerStatsImpl implements ConsumerStats {
         this.keyHashRanges = stats.keyHashRanges;
         this.keyHashRangeArrays = stats.keyHashRangeArrays;
         this.consumerName = stats.consumerName;
+        this.firstMessagesSentTimestamp = stats.firstMessagesSentTimestamp;
+        this.firstConsumedFlowTimestamp = stats.firstConsumedFlowTimestamp;
         return this;
     }
 

--- a/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
+++ b/pulsar-common/src/main/java/org/apache/pulsar/common/policies/data/stats/SubscriptionStatsImpl.java
@@ -93,6 +93,9 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
     /** Total rate of messages expired on this subscription (msg/s). */
     public double msgRateExpired;
 
+    /** The count of expired messages on this subscription. */
+    public long msgExpired;
+
     /** Total messages expired on this subscription. */
     public long totalMsgExpired;
 
@@ -209,6 +212,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
         unackedMessages = 0;
         type = null;
         msgRateExpired = 0;
+        msgExpired = 0;
         totalMsgExpired = 0;
         lastExpireTimestamp = 0L;
         lastMarkDeleteAdvancedTimestamp = 0L;
@@ -254,6 +258,7 @@ public class SubscriptionStatsImpl implements SubscriptionStats {
         this.unackedMessages += stats.unackedMessages;
         this.type = stats.type;
         this.msgRateExpired += stats.msgRateExpired;
+        this.msgExpired += stats.msgExpired;
         this.totalMsgExpired += stats.totalMsgExpired;
         this.isReplicated |= stats.isReplicated;
         this.isDurable |= stats.isDurable;

--- a/pulsar-metadata/pom.xml
+++ b/pulsar-metadata/pom.xml
@@ -62,12 +62,12 @@
     </dependency>
 
     <dependency>
-      <groupId>io.streamnative.oxia</groupId>
+      <groupId>io.github.oxia-db</groupId>
       <artifactId>oxia-client</artifactId>
     </dependency>
 
     <dependency>
-      <groupId>io.streamnative.oxia</groupId>
+      <groupId>io.github.oxia-db</groupId>
       <artifactId>oxia-testcontainers</artifactId>
       <scope>test</scope>
     </dependency>

--- a/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStore.java
+++ b/pulsar-metadata/src/main/java/org/apache/pulsar/metadata/impl/oxia/OxiaMetadataStore.java
@@ -19,15 +19,15 @@
 package org.apache.pulsar.metadata.impl.oxia;
 
 import io.opentelemetry.api.OpenTelemetry;
-import io.streamnative.oxia.client.api.AsyncOxiaClient;
-import io.streamnative.oxia.client.api.DeleteOption;
-import io.streamnative.oxia.client.api.Notification;
-import io.streamnative.oxia.client.api.OxiaClientBuilder;
-import io.streamnative.oxia.client.api.PutOption;
-import io.streamnative.oxia.client.api.PutResult;
-import io.streamnative.oxia.client.api.Version;
-import io.streamnative.oxia.client.api.exceptions.KeyAlreadyExistsException;
-import io.streamnative.oxia.client.api.exceptions.UnexpectedVersionIdException;
+import io.oxia.client.api.AsyncOxiaClient;
+import io.oxia.client.api.DeleteOption;
+import io.oxia.client.api.Notification;
+import io.oxia.client.api.OxiaClientBuilder;
+import io.oxia.client.api.PutOption;
+import io.oxia.client.api.PutResult;
+import io.oxia.client.api.Version;
+import io.oxia.client.api.exceptions.KeyAlreadyExistsException;
+import io.oxia.client.api.exceptions.UnexpectedVersionIdException;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -125,7 +125,7 @@ public class OxiaMetadataStore extends AbstractMetadataStore {
     }
 
     Optional<GetResult> convertGetResult(
-            String path, io.streamnative.oxia.client.api.GetResult result) {
+            String path, io.oxia.client.api.GetResult result) {
         if (result == null) {
             return Optional.empty();
         }

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/BaseMetadataStoreTest.java
@@ -22,7 +22,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
 import io.etcd.jetcd.launcher.EtcdCluster;
 import io.etcd.jetcd.test.EtcdClusterExtension;
-import io.streamnative.oxia.testcontainers.OxiaContainer;
+import io.oxia.testcontainers.OxiaContainer;
 import java.io.File;
 import java.net.URI;
 import java.util.Arrays;

--- a/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
+++ b/pulsar-metadata/src/test/java/org/apache/pulsar/metadata/MetadataStoreTest.java
@@ -42,10 +42,10 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
-import io.streamnative.oxia.client.ClientConfig;
-import io.streamnative.oxia.client.api.AsyncOxiaClient;
-import io.streamnative.oxia.client.session.SessionFactory;
-import io.streamnative.oxia.client.session.SessionManager;
+import io.oxia.client.ClientConfig;
+import io.oxia.client.api.AsyncOxiaClient;
+import io.oxia.client.session.SessionFactory;
+import io.oxia.client.session.SessionManager;
 import lombok.Cleanup;
 import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;


### PR DESCRIPTION
### Motivation

Customer got 
```
Got exception java.lang.IllegalStateException: Field 'message' is not set
  at org.apache.pulsar.common.api.proto.CommandLookupTopicResponse.getMessage(CommandLookupTopicResponse.java:220)
  at org.apache.pulsar.client.impl.ClientCnx.handleLookupResponse(ClientCnx.java:629)
  at org.apache.pulsar.common.protocol.PulsarDecoder.channelRead(PulsarDecoder.java:154)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:444)
  at io.netty.channel.AbstractChannelHandlerContext.invokeChannelRead(AbstractChannelHandlerContext.java:420)

```
in production.

I don't know exactly how the message ended up empty but:
* it is optional in protobuf so such cases should be anticipated
* in some cases it is set using `throwable.getMessage()` and who knows if that message was set.

### Modifications

added hasMessage() checks.
Passing the ServerError as string for the logging, null otherwise (similar to handlePartitionResponse's approach)


### Verifying this change

- [x] Make sure that the change passes the CI checks.

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

### Does this pull request potentially affect one of the following parts:

*NO*

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->
